### PR TITLE
Add startup time to "onReady" summary

### DIFF
--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -280,7 +280,7 @@ export default class MyHandler extends Handler {
                 true
             )} in pricelist | Listings cap: ${String(
                 this.bot.listingManager.cap
-            )} | Startup time: ${process.uptime().toFixed(0)}ms`
+            )} | Startup time: ${process.uptime().toFixed(0)}s`
         );
 
         this.bot.client.gamesPlayed(this.bot.options.game.playOnlyTF2 ? 440 : [this.customGameName, 440]);

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -274,15 +274,13 @@ export default class MyHandler extends Handler {
 
     onReady(): void {
         log.info(
-            'TF2Autobot v' +
-                process.env.BOT_VERSION +
-                ' is ready! ' +
-                pluralize('item', this.bot.pricelist.getLength(), true) +
-                ' in pricelist, ' +
-                pluralize('listing', this.bot.listingManager.listings.length, true) +
-                ' on www.backpack.tf (cap: ' +
-                String(this.bot.listingManager.cap) +
-                ')'
+            `TF2Autobot v${process.env.BOT_VERSION} is ready | ${pluralize(
+                'item',
+                this.bot.pricelist.getLength(),
+                true
+            )} in pricelist | Listings cap: ${String(
+                this.bot.listingManager.cap
+            )} | Startup time: ${process.uptime().toFixed(0)}ms`
         );
 
         this.bot.client.gamesPlayed(this.bot.options.game.playOnlyTF2 ? 440 : [this.customGameName, 440]);


### PR DESCRIPTION
Example of the new startup summary: 
```2020-12-14 00:39:43 info: TF2Autobot v2.2.5 is ready | 1 item in pricelist | Listings cap: 70 | Startup time: 6s```