### PR TITLE
v2.3.4 - patch

### DIFF
--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -777,6 +777,7 @@ export default class MyHandler extends Handler {
         let assetidsToCheck: string[] = [];
         let skuToCheck: string[] = [];
         let hasNoPrice = false;
+        let hasInvalidItemsOur = false;
 
         for (let i = 0; i < states.length; i++) {
             const buying = states[i];
@@ -898,6 +899,11 @@ export default class MyHandler extends Handler {
                     ) {
                         // Offer contains an item that we are not trading
                         hasInvalidItems = true;
+
+                        // If that particular item is on our side, then put to review
+                        if (which === 'our') {
+                            hasInvalidItemsOur = true;
+                        }
 
                         // await sleepasync().Promise.sleep(1 * 1000);
                         const price = (await this.bot.pricelist.getPricesTF(sku)) as GetPrices;
@@ -1284,6 +1290,7 @@ export default class MyHandler extends Handler {
             const isAcceptInvalidItems =
                 isInvalidItem &&
                 canAcceptInvalidItemsOverpay &&
+                !hasInvalidItemsOur &&
                 (exchange.our.value < exchange.their.value ||
                     (exchange.our.value === exchange.their.value && hasNoPrice)) &&
                 (isOverstocked ? canAcceptOverstockedOverpay : true) &&


### PR DESCRIPTION
- 🐛 fix false INVALID_ITEMS overpay
    - If `manualReview.invalidItems.givePrice` is `false` and `manualReview.invalidItems.acceptOverpay` is `true`, then if someone takes anything on our side that is not priced and their side has some value, the bot will accept the trade.
    - Now the trade will be held for review.