### PR TITLE
🔨 improve auto-check missing listings

### DIFF
--- a/src/classes/Commands/functions/manager.ts
+++ b/src/classes/Commands/functions/manager.ts
@@ -583,7 +583,7 @@ export function refreshListingsCommand(steamID: SteamID, bot: Bot): void {
             const isExist = newlistingsSKUs.find(sku => entry.sku === sku);
 
             if (!isExist) {
-                // undefined - listings does not exist but item is in the pricelist
+                // undefined - listing does not exist but item is in the pricelist
 
                 // Get amountCanBuy and amountCanSell (already cover intent and so on)
                 const amountCanBuy = inventory.amountCanTrade(entry.sku, true);
@@ -598,7 +598,7 @@ export function refreshListingsCommand(steamID: SteamID, bot: Bot): void {
                 return false;
             }
 
-            // Else if listings already exist on backpack.tf, ignore
+            // Else if listing already exist on backpack.tf, ignore
             return false;
         });
 
@@ -606,7 +606,7 @@ export function refreshListingsCommand(steamID: SteamID, bot: Bot): void {
             log.debug(
                 'Checking listings for ' +
                     pluralize('item', pricelist.length, true) +
-                    `[${pricelist.map(entry => entry.sku).join(', ')}] ...`
+                    ` [${pricelist.map(entry => entry.sku).join(', ')}] ...`
             );
 
             bot.sendMessage(steamID, 'Refreshing listings for ' + pluralize('item', pricelist.length, true) + '...');

--- a/src/classes/Commands/functions/manager.ts
+++ b/src/classes/Commands/functions/manager.ts
@@ -579,23 +579,36 @@ export function refreshListingsCommand(steamID: SteamID, bot: Bot): void {
 
         const inventory = bot.inventoryManager;
         const pricelist = bot.pricelist.getPrices.filter(entry => {
-            // Filter our pricelist to only the items that are missing.
-            const amountCanBuy = inventory.amountCanTrade(entry.sku, true);
-            const amountCanSell = inventory.amountCanTrade(entry.sku, false);
+            // First find out if lising for this item from bptf already exist.
+            const isExist = newlistingsSKUs.find(sku => entry.sku === sku);
 
-            if (
-                ([0, 2].includes(entry.intent) && amountCanBuy <= 0) ||
-                ([1, 2].includes(entry.intent) && amountCanSell <= 0)
-            ) {
-                // Ignore items we can't buy or sell
+            if (!isExist) {
+                // undefined - listings does not exist but item is in the pricelist
+
+                // Get amountCanBuy and amountCanSell (already cover intent and so on)
+                const amountCanBuy = inventory.amountCanTrade(entry.sku, true);
+                const amountCanSell = inventory.amountCanTrade(entry.sku, false);
+
+                if (amountCanBuy > 0 || amountCanSell > 0) {
+                    // if any of this more than 0, then return this entry
+                    return true;
+                }
+
+                // Else ignore
                 return false;
             }
 
-            return entry.enabled && !newlistingsSKUs.includes(entry.sku);
+            // Else if listings already exist on backpack.tf, ignore
+            return false;
         });
 
         if (pricelist.length > 0) {
-            log.debug('Checking listings for ' + pluralize('item', pricelist.length, true) + '...');
+            log.debug(
+                'Checking listings for ' +
+                    pluralize('item', pricelist.length, true) +
+                    `[${pricelist.map(entry => entry.sku).join(', ')}] ...`
+            );
+
             bot.sendMessage(steamID, 'Refreshing listings for ' + pluralize('item', pricelist.length, true) + '...');
 
             await bot.listings.recursiveCheckPricelist(pricelist, true);

--- a/src/classes/Commands/functions/manager.ts
+++ b/src/classes/Commands/functions/manager.ts
@@ -589,8 +589,12 @@ export function refreshListingsCommand(steamID: SteamID, bot: Bot): void {
                 const amountCanBuy = inventory.amountCanTrade(entry.sku, true);
                 const amountCanSell = inventory.amountCanTrade(entry.sku, false);
 
-                if (amountCanBuy > 0 || amountCanSell > 0) {
-                    // if any of this more than 0, then return this entry
+                if (
+                    (amountCanBuy > 0 && inventory.isCanAffordToBuy(entry.buy, inventory.getInventory)) ||
+                    amountCanSell > 0
+                ) {
+                    // if can amountCanBuy is more than 0 and isCanAffordToBuy is true OR amountCanSell is more than 0
+                    // return this entry
                     return true;
                 }
 

--- a/src/classes/InventoryManager.ts
+++ b/src/classes/InventoryManager.ts
@@ -84,6 +84,21 @@ export default class InventoryManager {
         return 0;
     }
 
+    isCanAffordToBuy(buyingPrice: Currencies, inventory: Inventory): boolean {
+        const buyingKeys = buyingPrice.keys;
+        const buyingMetalValue = Currencies.toScrap(buyingPrice.metal);
+
+        const avaiableCurrencies = inventory.getCurrencies([]);
+
+        const availableKeys = avaiableCurrencies['5021;6'].length;
+        const availableMetalsValue =
+            avaiableCurrencies['5002;6'].length * 9 +
+            avaiableCurrencies['5001;6'].length * 3 +
+            avaiableCurrencies['5000;6'].length;
+
+        return (buyingKeys > 0 ? availableKeys >= buyingKeys : true) && availableMetalsValue >= buyingMetalValue;
+    }
+
     amountCanAfford(useKeys: boolean, price: Currencies, inventory: Inventory, weapons: string[]): number {
         const keyPrice = this.pricelist.getKeyPrice;
         const value = price.toValue(keyPrice.metal);

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -474,7 +474,7 @@ export default class MyHandler extends Handler {
                     const isExist = newlistingsSKUs.find(sku => entry.sku === sku);
 
                     if (!isExist) {
-                        // undefined - listings does not exist but item is in the pricelist
+                        // undefined - listing does not exist but item is in the pricelist
 
                         // Get amountCanBuy and amountCanSell (already cover intent and so on)
                         const amountCanBuy = inventory.amountCanTrade(entry.sku, true);
@@ -489,7 +489,7 @@ export default class MyHandler extends Handler {
                         return false;
                     }
 
-                    // Else if listings already exist on backpack.tf, ignore
+                    // Else if listing already exist on backpack.tf, ignore
                     return false;
                 });
 
@@ -497,7 +497,7 @@ export default class MyHandler extends Handler {
                     log.debug(
                         'Checking listings for ' +
                             pluralize('item', pricelist.length, true) +
-                            `[${pricelist.map(entry => entry.sku).join(', ')}] ...`
+                            ` [${pricelist.map(entry => entry.sku).join(', ')}] ...`
                     );
                     await this.bot.listings.recursiveCheckPricelist(pricelist, true);
                     log.debug('✅ Done checking ' + pluralize('item', pricelist.length, true));

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -470,23 +470,35 @@ export default class MyHandler extends Handler {
 
                 const inventory = this.bot.inventoryManager;
                 const pricelist = this.bot.pricelist.getPrices.filter(entry => {
-                    // Filter our pricelist to only the items that are missing.
-                    const amountCanBuy = inventory.amountCanTrade(entry.sku, true);
-                    const amountCanSell = inventory.amountCanTrade(entry.sku, false);
+                    // First find out if lising for this item from bptf already exist.
+                    const isExist = newlistingsSKUs.find(sku => entry.sku === sku);
 
-                    if (
-                        ([0, 2].includes(entry.intent) && amountCanBuy <= 0) ||
-                        ([1, 2].includes(entry.intent) && amountCanSell <= 0)
-                    ) {
-                        // Ignore items we can't buy or sell
+                    if (!isExist) {
+                        // undefined - listings does not exist but item is in the pricelist
+
+                        // Get amountCanBuy and amountCanSell (already cover intent and so on)
+                        const amountCanBuy = inventory.amountCanTrade(entry.sku, true);
+                        const amountCanSell = inventory.amountCanTrade(entry.sku, false);
+
+                        if (amountCanBuy > 0 || amountCanSell > 0) {
+                            // if any of this more than 0, then return this entry
+                            return true;
+                        }
+
+                        // Else ignore
                         return false;
                     }
 
-                    return entry.enabled && !newlistingsSKUs.includes(entry.sku);
+                    // Else if listings already exist on backpack.tf, ignore
+                    return false;
                 });
 
                 if (pricelist.length > 0) {
-                    log.debug('Checking listings for ' + pluralize('item', pricelist.length, true) + '...');
+                    log.debug(
+                        'Checking listings for ' +
+                            pluralize('item', pricelist.length, true) +
+                            `[${pricelist.map(entry => entry.sku).join(', ')}] ...`
+                    );
                     await this.bot.listings.recursiveCheckPricelist(pricelist, true);
                     log.debug('✅ Done checking ' + pluralize('item', pricelist.length, true));
                 } else {

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -480,8 +480,12 @@ export default class MyHandler extends Handler {
                         const amountCanBuy = inventory.amountCanTrade(entry.sku, true);
                         const amountCanSell = inventory.amountCanTrade(entry.sku, false);
 
-                        if (amountCanBuy > 0 || amountCanSell > 0) {
-                            // if any of this more than 0, then return this entry
+                        if (
+                            (amountCanBuy > 0 && inventory.isCanAffordToBuy(entry.buy, inventory.getInventory)) ||
+                            amountCanSell > 0
+                        ) {
+                            // if can amountCanBuy is more than 0 and isCanAffordToBuy is true OR amountCanSell is more than 0
+                            // return this entry
                             return true;
                         }
 


### PR DESCRIPTION
Based on my observation, some items are still missing and the bot said in the log that "❌ Nothing to refresh". I have to manually update to disable then re-enable it so the item will be listed to sell.

This commit might fix this issue.
Please review it.

Thank you.