### PR TITLE
small fix to `!offerinfo` command

### DIFF
--- a/src/classes/Commands/sub-classes/Review.ts
+++ b/src/classes/Commands/sub-classes/Review.ts
@@ -359,8 +359,8 @@ export default class ReviewCommands {
 
         const offerId = offerIdRegex[0];
 
-        const state = this.bot.manager.pollData.received[offerId];
-        if (state === undefined) {
+        const timestamp = this.bot.manager.pollData.timestamps[offerId];
+        if (timestamp === undefined) {
             return this.bot.sendMessage(steamID, 'Offer does not exist. ❌');
         }
 


### PR DESCRIPTION
- 🔨 check to exist with timestamps instead of received