### PR TITLE
refactor: 💡 change hot rod sheen emoji to cherry blossom

### DIFF
--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -666,7 +666,7 @@ export const DEFAULTS = {
          */
         sheens: {
             'Team Shine': '🔵🔴',
-            'Hot Rod': '🎗️',
+            'Hot Rod': '🌸',
             Manndarin: '🟠',
             'Deadly Daffodil': '🟡',
             'Mean Green': '🟢',


### PR DESCRIPTION
Self-explanatory. This change is done to account for variations in the `🎗️` emoji color across devices (see: (https://emojipedia.org/reminder-ribbon/)