### PR TITLE
🏹 Update on how the bot should pick weapons when constructing an offer

### DIFF
--- a/src/classes/Carts/UserCart.ts
+++ b/src/classes/Carts/UserCart.ts
@@ -165,10 +165,20 @@ export default class UserCart extends Cart {
             '5000;6': 0
         };
 
+        let remaining = price.toValue(useKeys ? keyPrice.metal : undefined);
+
+        const needToPickWeapons = remaining - Math.trunc(remaining) !== 0;
+        // Let say our selling price is 0.05 ref, so 0.05 - Math.trunc(0.05) = 0.05, it will be true.
+
+        if (this.isWeaponsAsCurrencyEnabled && needToPickWeapons) {
+            this.weapons.forEach(sku => {
+                currencyValues[sku] = 0.5;
+                pickedCurrencies[sku] = 0;
+            });
+        }
+
         const skus = Object.keys(currencyValues);
         const skusCount = skus.length;
-
-        let remaining = price.toValue(useKeys ? keyPrice.metal : undefined);
 
         let hasReversed = false;
         let reverse = false;
@@ -278,7 +288,8 @@ export default class UserCart extends Cart {
 
         log.debug('Done constructing offer', { picked: pickedCurrencies, change: remaining });
 
-        if (this.isWeaponsAsCurrencyEnabled) {
+        if (this.isWeaponsAsCurrencyEnabled && !needToPickWeapons) {
+            // if needToPickWeapons is false, then we add weapons after picking up metals.
             this.weapons.forEach(sku => {
                 pickedCurrencies[sku] = 0;
             });

--- a/src/classes/Carts/UserCart.ts
+++ b/src/classes/Carts/UserCart.ts
@@ -168,7 +168,8 @@ export default class UserCart extends Cart {
         let remaining = price.toValue(useKeys ? keyPrice.metal : undefined);
 
         const needToPickWeapons = remaining - Math.trunc(remaining) !== 0;
-        // Let say our selling price is 0.05 ref, so 0.05 - Math.trunc(0.05) = 0.05, it will be true.
+        // Let say our selling price is 0.05 ref, so convert to value (scrap) is
+        // 0.5 - Math.trunc(0.5) = 0.5, it will be true.
 
         if (this.isWeaponsAsCurrencyEnabled && needToPickWeapons) {
             this.weapons.forEach(sku => {

--- a/src/classes/Carts/UserCart.ts
+++ b/src/classes/Carts/UserCart.ts
@@ -165,13 +165,6 @@ export default class UserCart extends Cart {
             '5000;6': 0
         };
 
-        if (this.isWeaponsAsCurrencyEnabled) {
-            this.weapons.forEach(sku => {
-                currencyValues[sku] = 0.5;
-                pickedCurrencies[sku] = 0;
-            });
-        }
-
         const skus = Object.keys(currencyValues);
         const skusCount = skus.length;
 
@@ -284,6 +277,12 @@ export default class UserCart extends Cart {
         }
 
         log.debug('Done constructing offer', { picked: pickedCurrencies, change: remaining });
+
+        if (this.isWeaponsAsCurrencyEnabled) {
+            this.weapons.forEach(sku => {
+                pickedCurrencies[sku] = 0;
+            });
+        }
 
         return {
             currencies: pickedCurrencies,


### PR DESCRIPTION
- Only pick weapons if needed (of course only if your `miscSettings.weaponsAsCurrency.enable` is set to `true`).
- closes #341

## Screenshots
- buying item with 0.05 ref price
![image](https://user-images.githubusercontent.com/47635037/108110338-11d9ea80-70ce-11eb-9654-792acca6fa6f.png)
![image](https://user-images.githubusercontent.com/47635037/108110347-16060800-70ce-11eb-902c-7c77bb69eae9.png)
![image](https://user-images.githubusercontent.com/47635037/108110354-17cfcb80-70ce-11eb-9b1d-afe16c9a3a5d.png)

- buying item with no 0.05 ref
![image](https://user-images.githubusercontent.com/47635037/108110390-27e7ab00-70ce-11eb-8a6e-91723caa1acb.png)
![image](https://user-images.githubusercontent.com/47635037/108110427-333ad680-70ce-11eb-97c7-48df8c0a83f8.png)
![image](https://user-images.githubusercontent.com/47635037/108110408-2d44f580-70ce-11eb-9f7f-adb6266155d0.png)