### PR TITLE
v3.4.4

### DIFF
--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -73,7 +73,7 @@ export default class Commands {
     }
 
     useStatsCommand(steamID: SteamID): void {
-        this.status.statsCommand(steamID);
+        void this.status.statsCommand(steamID);
     }
 
     useUpdateOptionsCommand(steamID: SteamID | null, message: string): void {
@@ -219,7 +219,7 @@ export default class Commands {
         } else if (command === 'refreshlist' && isAdmin) {
             this.manager.refreshListingsCommand(steamID);
         } else if (command === 'stats' && isAdmin) {
-            this.status.statsCommand(steamID);
+            void this.status.statsCommand(steamID);
         } else if (command === 'statsdw' && isAdmin) {
             this.status.statsDWCommand(steamID);
         } else if (command === 'itemstats' && (isAdmin || isWhitelisted)) {

--- a/src/classes/Commands/sub-classes/Status.ts
+++ b/src/classes/Commands/sub-classes/Status.ts
@@ -300,7 +300,7 @@ export default class StatusCommands {
                     const netProfit = Currencies.toCurrencies(totalSoldValue - totalBoughtValue, keyPrice);
                     const netProfitToString = netProfit.toString();
 
-                    reply += '\n\nOverall pass 30 days summary:';
+                    reply += '\n\nOverall past 30 days summary:';
                     reply += `\n• Total bought value: ${boughtValueToString}${
                         boughtValueToString.includes('key') ? ` (${Currencies.toRefined(totalBoughtValue)})` : ''
                     }`;

--- a/src/classes/Commands/sub-classes/Status.ts
+++ b/src/classes/Commands/sub-classes/Status.ts
@@ -17,10 +17,10 @@ export default class StatusCommands {
         this.bot = bot;
     }
 
-    statsCommand(steamID: SteamID): void {
+    async statsCommand(steamID: SteamID): Promise<void> {
         const tradesFromEnv = this.bot.options.statistics.lastTotalTrades;
         const trades = stats(this.bot);
-        const profits = profit(this.bot, Math.floor((Date.now() - 86400000) / 1000)); //since -24h
+        const profits = await profit(this.bot, Math.floor((Date.now() - 86400000) / 1000)); //since -24h
 
         const keyPrices = this.bot.pricelist.getKeyPrices;
 

--- a/src/classes/Commands/sub-classes/Status.ts
+++ b/src/classes/Commands/sub-classes/Status.ts
@@ -127,7 +127,7 @@ export default class StatusCommands {
             : [];
         if (
             !(this.bot.options.miscSettings.weaponsAsCurrency.enable && weapons.includes(sku)) &&
-            !['5021;6', '5000;6', '5001;6', '5002;6'].includes(sku)
+            !['5000;6', '5001;6', '5002;6'].includes(sku)
         ) {
             const now = Math.floor(Date.now() / 1000);
 
@@ -279,7 +279,7 @@ export default class StatusCommands {
                 reply = err as string;
             }
         } else {
-            reply = 'enable for keys and weapons - currently not implemented';
+            reply = 'Stats for currency is not enabled.';
         }
 
         this.bot.sendMessage(steamID, reply);

--- a/src/classes/Commands/sub-classes/Status.ts
+++ b/src/classes/Commands/sub-classes/Status.ts
@@ -1,6 +1,7 @@
 import SteamID from 'steamid';
 import pluralize from 'pluralize';
 import Currencies from 'tf2-currencies-2';
+import SKU from 'tf2-sku-2';
 import { getItemAndAmount, testSKU } from '../functions/utils';
 import Bot from '../../Bot';
 import CommandParser from '../../CommandParser';
@@ -118,7 +119,7 @@ export default class StatusCommands {
             sku = info.match.sku;
         }
 
-        let reply = '';
+        let reply = `Recorded sales for ${this.bot.schema.getName(SKU.fromString(sku))}\n\n`;
 
         const weapons = this.bot.handler.isWeaponsAsCurrency.enable
             ? this.bot.handler.isWeaponsAsCurrency.withUncraft

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -1182,6 +1182,8 @@ export default class MyHandler extends Handler {
                         const isCrateOrCases = item.crateseries !== null || ['5737;6', '5738;6'].includes(sku);
                         // 5737;6 and 5738;6 - Mann Co. Stockpile Crate
 
+                        const isWinterNoiseMaker = ['673;6'].includes(sku);
+
                         const isSkinsOrWarPaints = item.wear !== null;
 
                         let itemSuggestedValue: string;
@@ -1195,7 +1197,8 @@ export default class MyHandler extends Handler {
                             if (
                                 opt.offerReceived.invalidItems.givePrice &&
                                 !isSkinsOrWarPaints &&
-                                !isCrateOrCases && // both of these should be false in order to be true
+                                !isCrateOrCases &&
+                                !isWinterNoiseMaker && // all of these (with !) should be false in order to be true
                                 isCanBePriced
                             ) {
                                 // if offerReceived.invalidItems.givePrice is set to true (enable) and items is not skins/war paint/crate/cases,

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -597,7 +597,7 @@ export default class MyHandler extends Handler {
 
                 if (times.some(time => now.includes(time))) {
                     if (opt.discordWebhook.sendStats.enable && opt.discordWebhook.sendStats.url !== '') {
-                        sendStats(this.bot);
+                        void sendStats(this.bot);
                     } else {
                         this.bot.getAdmins.forEach(admin => {
                             this.commands.useStatsCommand(admin);

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -1194,7 +1194,8 @@ export default class MyHandler extends Handler {
 
                             if (
                                 opt.offerReceived.invalidItems.givePrice &&
-                                (!isSkinsOrWarPaints || !isCrateOrCases) &&
+                                !isSkinsOrWarPaints &&
+                                !isCrateOrCases && // both of these should be false in order to be true
                                 isCanBePriced
                             ) {
                                 // if offerReceived.invalidItems.givePrice is set to true (enable) and items is not skins/war paint/crate/cases,

--- a/src/lib/DiscordWebhook/sendStats.ts
+++ b/src/lib/DiscordWebhook/sendStats.ts
@@ -7,11 +7,11 @@ import log from '../logger';
 import { stats, profit, timeNow } from '../../lib/tools/export';
 import Bot from '../../classes/Bot';
 
-export default function sendStats(bot: Bot, forceSend = false, steamID?: SteamID): void {
+export default async function sendStats(bot: Bot, forceSend = false, steamID?: SteamID): Promise<void> {
     const optDW = bot.options.discordWebhook;
     const botInfo = bot.handler.getBotInfo;
     const trades = stats(bot);
-    const profits = profit(bot, Math.floor((Date.now() - 86400000) / 1000));
+    const profits = await profit(bot, Math.floor((Date.now() - 86400000) / 1000));
 
     const tradesFromEnv = bot.options.statistics.lastTotalTrades;
     const keyPrices = bot.pricelist.getKeyPrices;

--- a/src/lib/tools/itemStats.ts
+++ b/src/lib/tools/itemStats.ts
@@ -82,7 +82,7 @@ export default function itemStats(bot: Bot, SKU: string): Promise<{ bought: Item
                         if (
                             !(
                                 (bot.options.miscSettings.weaponsAsCurrency.enable && weapons.includes(sku)) ||
-                                ['5021;6', '5000;6', '5001;6', '5002;6'].includes(sku)
+                                ['5000;6', '5001;6', '5002;6'].includes(sku)
                             )
                         ) {
                             // if it is not currency
@@ -114,7 +114,7 @@ export default function itemStats(bot: Bot, SKU: string): Promise<{ bought: Item
                         if (
                             !(
                                 (bot.options.miscSettings.weaponsAsCurrency.enable && weapons.includes(sku)) ||
-                                ['5021;6', '5000;6', '5001;6', '5002;6'].includes(sku)
+                                ['5000;6', '5001;6', '5002;6'].includes(sku)
                             )
                         ) {
                             if (!Object.prototype.hasOwnProperty.call(trades[i].prices, sku)) {

--- a/src/lib/tools/profit.ts
+++ b/src/lib/tools/profit.ts
@@ -113,7 +113,7 @@ export default async function profit(
                         if (
                             !(
                                 (bot.options.miscSettings.weaponsAsCurrency.enable && weapons.includes(sku)) ||
-                                ['5021;6', '5000;6', '5001;6', '5002;6'].includes(sku)
+                                ['5000;6', '5001;6', '5002;6'].includes(sku)
                             )
                         ) {
                             // if it is not currency
@@ -159,7 +159,7 @@ export default async function profit(
                         if (
                             !(
                                 (bot.options.miscSettings.weaponsAsCurrency.enable && weapons.includes(sku)) ||
-                                ['5021;6', '5000;6', '5001;6', '5002;6'].includes(sku)
+                                ['5000;6', '5001;6', '5002;6'].includes(sku)
                             )
                         ) {
                             if (!Object.prototype.hasOwnProperty.call(trades[i].prices, sku)) {

--- a/src/lib/tools/profit.ts
+++ b/src/lib/tools/profit.ts
@@ -70,11 +70,12 @@ export default async function profit(
                     continue;
                 }
 
-                const ourDictCount = Object.keys(trades[i].dict.our).length;
+                const ourDicts = Object.keys(trades[i].dict.our);
+                const ourDictsCount = ourDicts.length;
 
-                if (typeof ourDictCount === 'undefined') {
+                if (typeof ourDicts === 'undefined') {
                     isGift = true; // no items on our side, so it is probably gift
-                } else if (ourDictCount > 0) {
+                } else if (ourDictsCount > 0) {
                     // trade is not a gift
                     if (!Object.prototype.hasOwnProperty.call(trades[i], 'value')) {
                         // trade is missing value object

--- a/src/lib/tools/profit.ts
+++ b/src/lib/tools/profit.ts
@@ -48,41 +48,41 @@ export default async function profit(
             let profitTimed = 0;
 
             const tracker = new itemTracker();
-
             const tradesCount = trades.length;
 
             for (let i = 0; i < tradesCount; i++) {
-                // const trade = trades[i];
-                if (!(trades[i].handledByUs && trades[i].isAccepted)) {
+                const trade = trades[i];
+
+                if (!(trade.handledByUs && trade.isAccepted)) {
                     // trade was not accepted, go to next trade
                     continue;
                 }
 
-                if (trades[i].action?.reason === 'ADMIN' || bot.isAdmin(trades[i].partner)) {
+                if (trade.action?.reason === 'ADMIN' || bot.isAdmin(trade.partner)) {
                     // trades was from ADMIN, ignore
                     continue;
                 }
 
                 let isGift = false;
 
-                if (!Object.prototype.hasOwnProperty.call(trades[i], 'dict')) {
+                if (!Object.prototype.hasOwnProperty.call(trade, 'dict')) {
                     // trade has no items involved (not possible, but who knows)
                     continue;
                 }
 
-                const ourDicts = Object.keys(trades[i].dict.our);
+                const ourDicts = Object.keys(trade.dict.our);
                 const ourDictsCount = ourDicts.length;
 
                 if (typeof ourDicts === 'undefined') {
                     isGift = true; // no items on our side, so it is probably gift
                 } else if (ourDictsCount > 0) {
                     // trade is not a gift
-                    if (!Object.prototype.hasOwnProperty.call(trades[i], 'value')) {
+                    if (!Object.prototype.hasOwnProperty.call(trade, 'value')) {
                         // trade is missing value object
                         continue;
                     }
 
-                    if (!(Object.keys(trades[i].prices).length > 0)) {
+                    if (!(Object.keys(trade.prices).length > 0)) {
                         // have no prices, broken data, skip
                         continue;
                     }
@@ -90,26 +90,26 @@ export default async function profit(
                     isGift = true; // no items on our side, so it is probably gift
                 }
 
-                if (typeof trades[i].value === 'undefined') {
-                    trades[i].value = {};
+                if (typeof trade.value === 'undefined') {
+                    trade.value = {};
                 }
 
-                if (typeof trades[i].value.rate === 'undefined') {
-                    if (!Object.prototype.hasOwnProperty.call(trades[i], 'value')) {
+                if (typeof trade.value.rate === 'undefined') {
+                    if (!Object.prototype.hasOwnProperty.call(trade, 'value')) {
                         // in case it was gift
-                        trades[i].value = {};
+                        trade.value = {};
                     }
 
-                    trades[i].value.rate = keyPrice.metal; // set key value to current value if it is not defined
+                    trade.value.rate = keyPrice.metal; // set key value to current value if it is not defined
                 }
 
-                for (const sku in trades[i].dict.their) {
+                for (const sku in trade.dict.their) {
                     // item bought
-                    if (Object.prototype.hasOwnProperty.call(trades[i].dict.their, sku)) {
+                    if (Object.prototype.hasOwnProperty.call(trade.dict.their, sku)) {
                         const itemCount =
-                            typeof trades[i].dict.their[sku] === 'object'
-                                ? (trades[i].dict.their[sku]['amount'] as number) // pollData v2.2.0 until v.2.3.5
-                                : trades[i].dict.their[sku]; // pollData before v2.2.0 and/or v3.0.0 or later
+                            typeof trade.dict.their[sku] === 'object'
+                                ? (trade.dict.their[sku]['amount'] as number) // pollData v2.2.0 until v.2.3.5
+                                : trade.dict.their[sku]; // pollData before v2.2.0 and/or v3.0.0 or later
 
                         if (
                             !(
@@ -119,29 +119,28 @@ export default async function profit(
                         ) {
                             // if it is not currency
                             if (isGift) {
-                                if (!Object.prototype.hasOwnProperty.call(trades[i], 'prices')) {
-                                    trades[i].prices = {};
+                                if (!Object.prototype.hasOwnProperty.call(trade, 'prices')) {
+                                    trade.prices = {};
                                 }
 
-                                trades[i].prices[sku] = {
+                                trade.prices[sku] = {
                                     // set price to 0 because it's a gift
                                     buy: new Currencies({
                                         keys: 0,
                                         metal: 0
                                     })
                                 };
-                            } else if (!Object.prototype.hasOwnProperty.call(trades[i].prices, sku)) {
+                            } else if (!Object.prototype.hasOwnProperty.call(trade.prices, sku)) {
                                 continue; // item is not in pricelist, so we will just skip it
                             }
 
-                            // const prices = trades[i].prices[sku].buy;
                             const tempProfit = tracker.boughtItem(
                                 itemCount,
                                 sku,
-                                trades[i].prices[sku].buy,
-                                trades[i].value.rate
+                                trade.prices[sku].buy,
+                                trade.value.rate
                             );
-                            if (trades[i].time >= start) {
+                            if (trade.time >= start) {
                                 // is within time of interest
                                 profitTimed += tempProfit;
                             }
@@ -150,12 +149,12 @@ export default async function profit(
                     }
                 }
 
-                for (const sku in trades[i].dict.our) {
-                    if (Object.prototype.hasOwnProperty.call(trades[i].dict.our, sku)) {
+                for (const sku in trade.dict.our) {
+                    if (Object.prototype.hasOwnProperty.call(trade.dict.our, sku)) {
                         const itemCount =
-                            typeof trades[i].dict.our[sku] === 'object'
-                                ? (trades[i].dict.our[sku]['amount'] as number) // pollData v2.2.0 until v.2.3.5
-                                : trades[i].dict.our[sku]; // pollData before v2.2.0 and/or v3.0.0 or later
+                            typeof trade.dict.our[sku] === 'object'
+                                ? (trade.dict.our[sku]['amount'] as number) // pollData v2.2.0 until v.2.3.5
+                                : trade.dict.our[sku]; // pollData before v2.2.0 and/or v3.0.0 or later
 
                         if (
                             !(
@@ -163,17 +162,17 @@ export default async function profit(
                                 ['5000;6', '5001;6', '5002;6'].includes(sku)
                             )
                         ) {
-                            if (!Object.prototype.hasOwnProperty.call(trades[i].prices, sku)) {
+                            if (!Object.prototype.hasOwnProperty.call(trade.prices, sku)) {
                                 continue; // item is not in pricelist, so we will just skip it
                             }
-                            // const prices = trades[i].prices[sku].sell;
+
                             const tempProfit = tracker.soldItem(
                                 itemCount,
                                 sku,
-                                trades[i].prices[sku].sell,
-                                trades[i].value.rate
+                                trade.prices[sku].sell,
+                                trade.value.rate
                             );
-                            if (trades[i].time >= start) {
+                            if (trade.time >= start) {
                                 // is within time of interest
                                 profitTimed += tempProfit;
                             }
@@ -184,18 +183,18 @@ export default async function profit(
 
                 if (!isGift) {
                     // calculate overprice profit
-                    if (trades[i].time >= start) {
+                    if (trade.time >= start) {
                         // is within time of interest
                         profitTimed +=
-                            tracker.convert(trades[i].value.their, trades[i].value.rate) -
-                            tracker.convert(trades[i].value.our, trades[i].value.rate);
+                            tracker.convert(trade.value.their, trade.value.rate) -
+                            tracker.convert(trade.value.our, trade.value.rate);
                     }
                     tradeProfit +=
-                        tracker.convert(trades[i].value.their, trades[i].value.rate) -
-                        tracker.convert(trades[i].value.our, trades[i].value.rate);
+                        tracker.convert(trade.value.their, trade.value.rate) -
+                        tracker.convert(trade.value.our, trade.value.rate);
                     overpriceProfit +=
-                        tracker.convert(trades[i].value.their, trades[i].value.rate) -
-                        tracker.convert(trades[i].value.our, trades[i].value.rate);
+                        tracker.convert(trade.value.their, trade.value.rate) -
+                        tracker.convert(trade.value.our, trade.value.rate);
                 }
             }
 

--- a/src/lib/tools/profit.ts
+++ b/src/lib/tools/profit.ts
@@ -6,224 +6,226 @@ import { OfferData } from '@tf2autobot/tradeoffer-manager';
 
 // reference: https://github.com/ZeusJunior/tf2-automatic-gui/blob/master/app/profit.js
 
-export default function profit(
+export default async function profit(
     bot: Bot,
     start = 0
-): { tradeProfit: number; overpriceProfit: number; since: number; profitTimed: number } {
-    const pollData = bot.manager.pollData;
-    const now = dayjs();
+): Promise<{ tradeProfit: number; overpriceProfit: number; since: number; profitTimed: number }> {
+    return new Promise(resolve => {
+        const pollData = bot.manager.pollData;
+        const now = dayjs();
 
-    if (pollData.offerData) {
-        const trades = Object.keys(pollData.offerData).map(offerID => {
-            const ret = pollData.offerData[offerID] as OfferDataWithTime;
-            ret.time = pollData.timestamps[offerID];
-            return ret;
-        });
-        trades.sort((a, b) => {
-            const aTime = a.handleTimestamp;
-            const bTime = b.handleTimestamp;
+        if (pollData.offerData) {
+            const trades = Object.keys(pollData.offerData).map(offerID => {
+                const ret = pollData.offerData[offerID] as OfferDataWithTime;
+                ret.time = pollData.timestamps[offerID];
+                return ret;
+            });
+            trades.sort((a, b) => {
+                const aTime = a.handleTimestamp;
+                const bTime = b.handleTimestamp;
 
-            // check for undefined time, sort those at the beginning, they will be skipped
-            if ((!aTime || isNaN(aTime)) && !(!bTime || isNaN(bTime))) return -1;
-            if (!(!aTime || isNaN(aTime)) && (!bTime || isNaN(bTime))) return 1;
-            if ((!aTime || isNaN(aTime)) && (!bTime || isNaN(bTime))) return 0;
-            return aTime - bTime;
-        });
+                // check for undefined time, sort those at the beginning, they will be skipped
+                if ((!aTime || isNaN(aTime)) && !(!bTime || isNaN(bTime))) return -1;
+                if (!(!aTime || isNaN(aTime)) && (!bTime || isNaN(bTime))) return 1;
+                if ((!aTime || isNaN(aTime)) && (!bTime || isNaN(bTime))) return 0;
+                return aTime - bTime;
+            });
 
-        const timeSince =
-            +bot.options.statistics.profitDataSinceInUnix === 0
-                ? pollData.timestamps[Object.keys(pollData.offerData)[0]]
-                : +bot.options.statistics.profitDataSinceInUnix;
+            const timeSince =
+                +bot.options.statistics.profitDataSinceInUnix === 0
+                    ? pollData.timestamps[Object.keys(pollData.offerData)[0]]
+                    : +bot.options.statistics.profitDataSinceInUnix;
 
-        const keyPrice = bot.pricelist.getKeyPrice;
-        const weapons = bot.handler.isWeaponsAsCurrency.enable
-            ? bot.handler.isWeaponsAsCurrency.withUncraft
-                ? bot.craftWeapons.concat(bot.uncraftWeapons)
-                : bot.craftWeapons
-            : [];
+            const keyPrice = bot.pricelist.getKeyPrice;
+            const weapons = bot.handler.isWeaponsAsCurrency.enable
+                ? bot.handler.isWeaponsAsCurrency.withUncraft
+                    ? bot.craftWeapons.concat(bot.uncraftWeapons)
+                    : bot.craftWeapons
+                : [];
 
-        let overpriceProfit = 0;
-        let tradeProfit = 0;
-        let profitTimed = 0;
+            let overpriceProfit = 0;
+            let tradeProfit = 0;
+            let profitTimed = 0;
 
-        const tracker = new itemTracker();
+            const tracker = new itemTracker();
 
-        const tradesCount = trades.length;
+            const tradesCount = trades.length;
 
-        for (let i = 0; i < tradesCount; i++) {
-            // const trade = trades[i];
-            if (!(trades[i].handledByUs && trades[i].isAccepted)) {
-                // trade was not accepted, go to next trade
-                continue;
-            }
-
-            if (trades[i].action?.reason === 'ADMIN' || bot.isAdmin(trades[i].partner)) {
-                // trades was from ADMIN, ignore
-                continue;
-            }
-
-            let isGift = false;
-
-            if (!Object.prototype.hasOwnProperty.call(trades[i], 'dict')) {
-                // trade has no items involved (not possible, but who knows)
-                continue;
-            }
-
-            const ourDictCount = Object.keys(trades[i].dict.our).length;
-
-            if (typeof ourDictCount === 'undefined') {
-                isGift = true; // no items on our side, so it is probably gift
-            } else if (ourDictCount > 0) {
-                // trade is not a gift
-                if (!Object.prototype.hasOwnProperty.call(trades[i], 'value')) {
-                    // trade is missing value object
+            for (let i = 0; i < tradesCount; i++) {
+                // const trade = trades[i];
+                if (!(trades[i].handledByUs && trades[i].isAccepted)) {
+                    // trade was not accepted, go to next trade
                     continue;
                 }
 
-                if (!(Object.keys(trades[i].prices).length > 0)) {
-                    // have no prices, broken data, skip
+                if (trades[i].action?.reason === 'ADMIN' || bot.isAdmin(trades[i].partner)) {
+                    // trades was from ADMIN, ignore
                     continue;
                 }
-            } else {
-                isGift = true; // no items on our side, so it is probably gift
-            }
 
-            if (typeof trades[i].value === 'undefined') {
-                trades[i].value = {};
-            }
+                let isGift = false;
 
-            if (typeof trades[i].value.rate === 'undefined') {
-                if (!Object.prototype.hasOwnProperty.call(trades[i], 'value')) {
-                    // in case it was gift
+                if (!Object.prototype.hasOwnProperty.call(trades[i], 'dict')) {
+                    // trade has no items involved (not possible, but who knows)
+                    continue;
+                }
+
+                const ourDictCount = Object.keys(trades[i].dict.our).length;
+
+                if (typeof ourDictCount === 'undefined') {
+                    isGift = true; // no items on our side, so it is probably gift
+                } else if (ourDictCount > 0) {
+                    // trade is not a gift
+                    if (!Object.prototype.hasOwnProperty.call(trades[i], 'value')) {
+                        // trade is missing value object
+                        continue;
+                    }
+
+                    if (!(Object.keys(trades[i].prices).length > 0)) {
+                        // have no prices, broken data, skip
+                        continue;
+                    }
+                } else {
+                    isGift = true; // no items on our side, so it is probably gift
+                }
+
+                if (typeof trades[i].value === 'undefined') {
                     trades[i].value = {};
                 }
 
-                trades[i].value.rate = keyPrice.metal; // set key value to current value if it is not defined
-            }
+                if (typeof trades[i].value.rate === 'undefined') {
+                    if (!Object.prototype.hasOwnProperty.call(trades[i], 'value')) {
+                        // in case it was gift
+                        trades[i].value = {};
+                    }
 
-            for (const sku in trades[i].dict.their) {
-                // item bought
-                if (Object.prototype.hasOwnProperty.call(trades[i].dict.their, sku)) {
-                    const itemCount =
-                        typeof trades[i].dict.their[sku] === 'object'
-                            ? (trades[i].dict.their[sku]['amount'] as number) // pollData v2.2.0 until v.2.3.5
-                            : trades[i].dict.their[sku]; // pollData before v2.2.0 and/or v3.0.0 or later
+                    trades[i].value.rate = keyPrice.metal; // set key value to current value if it is not defined
+                }
 
-                    if (
-                        !(
-                            (bot.options.miscSettings.weaponsAsCurrency.enable && weapons.includes(sku)) ||
-                            ['5021;6', '5000;6', '5001;6', '5002;6'].includes(sku)
-                        )
-                    ) {
-                        // if it is not currency
-                        if (isGift) {
-                            if (!Object.prototype.hasOwnProperty.call(trades[i], 'prices')) {
-                                trades[i].prices = {};
+                for (const sku in trades[i].dict.their) {
+                    // item bought
+                    if (Object.prototype.hasOwnProperty.call(trades[i].dict.their, sku)) {
+                        const itemCount =
+                            typeof trades[i].dict.their[sku] === 'object'
+                                ? (trades[i].dict.their[sku]['amount'] as number) // pollData v2.2.0 until v.2.3.5
+                                : trades[i].dict.their[sku]; // pollData before v2.2.0 and/or v3.0.0 or later
+
+                        if (
+                            !(
+                                (bot.options.miscSettings.weaponsAsCurrency.enable && weapons.includes(sku)) ||
+                                ['5021;6', '5000;6', '5001;6', '5002;6'].includes(sku)
+                            )
+                        ) {
+                            // if it is not currency
+                            if (isGift) {
+                                if (!Object.prototype.hasOwnProperty.call(trades[i], 'prices')) {
+                                    trades[i].prices = {};
+                                }
+
+                                trades[i].prices[sku] = {
+                                    // set price to 0 because it's a gift
+                                    buy: new Currencies({
+                                        keys: 0,
+                                        metal: 0
+                                    })
+                                };
+                            } else if (!Object.prototype.hasOwnProperty.call(trades[i].prices, sku)) {
+                                continue; // item is not in pricelist, so we will just skip it
                             }
 
-                            trades[i].prices[sku] = {
-                                // set price to 0 because it's a gift
-                                buy: new Currencies({
-                                    keys: 0,
-                                    metal: 0
-                                })
-                            };
-                        } else if (!Object.prototype.hasOwnProperty.call(trades[i].prices, sku)) {
-                            continue; // item is not in pricelist, so we will just skip it
+                            // const prices = trades[i].prices[sku].buy;
+                            const tempProfit = tracker.boughtItem(
+                                itemCount,
+                                sku,
+                                trades[i].prices[sku].buy,
+                                trades[i].value.rate
+                            );
+                            if (trades[i].time >= start) {
+                                // is within time of interest
+                                profitTimed += tempProfit;
+                            }
+                            tradeProfit += tempProfit;
                         }
-
-                        // const prices = trades[i].prices[sku].buy;
-                        const tempProfit = tracker.boughtItem(
-                            itemCount,
-                            sku,
-                            trades[i].prices[sku].buy,
-                            trades[i].value.rate
-                        );
-                        if (trades[i].time >= start) {
-                            // is within time of interest
-                            profitTimed += tempProfit;
-                        }
-                        tradeProfit += tempProfit;
                     }
                 }
-            }
 
-            for (const sku in trades[i].dict.our) {
-                if (Object.prototype.hasOwnProperty.call(trades[i].dict.our, sku)) {
-                    const itemCount =
-                        typeof trades[i].dict.our[sku] === 'object'
-                            ? (trades[i].dict.our[sku]['amount'] as number) // pollData v2.2.0 until v.2.3.5
-                            : trades[i].dict.our[sku]; // pollData before v2.2.0 and/or v3.0.0 or later
+                for (const sku in trades[i].dict.our) {
+                    if (Object.prototype.hasOwnProperty.call(trades[i].dict.our, sku)) {
+                        const itemCount =
+                            typeof trades[i].dict.our[sku] === 'object'
+                                ? (trades[i].dict.our[sku]['amount'] as number) // pollData v2.2.0 until v.2.3.5
+                                : trades[i].dict.our[sku]; // pollData before v2.2.0 and/or v3.0.0 or later
 
-                    if (
-                        !(
-                            (bot.options.miscSettings.weaponsAsCurrency.enable && weapons.includes(sku)) ||
-                            ['5021;6', '5000;6', '5001;6', '5002;6'].includes(sku)
-                        )
-                    ) {
-                        if (!Object.prototype.hasOwnProperty.call(trades[i].prices, sku)) {
-                            continue; // item is not in pricelist, so we will just skip it
+                        if (
+                            !(
+                                (bot.options.miscSettings.weaponsAsCurrency.enable && weapons.includes(sku)) ||
+                                ['5021;6', '5000;6', '5001;6', '5002;6'].includes(sku)
+                            )
+                        ) {
+                            if (!Object.prototype.hasOwnProperty.call(trades[i].prices, sku)) {
+                                continue; // item is not in pricelist, so we will just skip it
+                            }
+                            // const prices = trades[i].prices[sku].sell;
+                            const tempProfit = tracker.soldItem(
+                                itemCount,
+                                sku,
+                                trades[i].prices[sku].sell,
+                                trades[i].value.rate
+                            );
+                            if (trades[i].time >= start) {
+                                // is within time of interest
+                                profitTimed += tempProfit;
+                            }
+                            tradeProfit += tempProfit;
                         }
-                        // const prices = trades[i].prices[sku].sell;
-                        const tempProfit = tracker.soldItem(
-                            itemCount,
-                            sku,
-                            trades[i].prices[sku].sell,
-                            trades[i].value.rate
-                        );
-                        if (trades[i].time >= start) {
-                            // is within time of interest
-                            profitTimed += tempProfit;
-                        }
-                        tradeProfit += tempProfit;
                     }
                 }
-            }
 
-            if (!isGift) {
-                // calculate overprice profit
-                if (trades[i].time >= start) {
-                    // is within time of interest
-                    profitTimed +=
+                if (!isGift) {
+                    // calculate overprice profit
+                    if (trades[i].time >= start) {
+                        // is within time of interest
+                        profitTimed +=
+                            tracker.convert(trades[i].value.their, trades[i].value.rate) -
+                            tracker.convert(trades[i].value.our, trades[i].value.rate);
+                    }
+                    tradeProfit +=
+                        tracker.convert(trades[i].value.their, trades[i].value.rate) -
+                        tracker.convert(trades[i].value.our, trades[i].value.rate);
+                    overpriceProfit +=
                         tracker.convert(trades[i].value.their, trades[i].value.rate) -
                         tracker.convert(trades[i].value.our, trades[i].value.rate);
                 }
-                tradeProfit +=
-                    tracker.convert(trades[i].value.their, trades[i].value.rate) -
-                    tracker.convert(trades[i].value.our, trades[i].value.rate);
-                overpriceProfit +=
-                    tracker.convert(trades[i].value.their, trades[i].value.rate) -
-                    tracker.convert(trades[i].value.our, trades[i].value.rate);
             }
+
+            const fromPrevious = {
+                made: Currencies.toScrap(bot.options.statistics.lastTotalProfitMadeInRef),
+                overpay: Currencies.toScrap(bot.options.statistics.lastTotalProfitOverpayInRef)
+            };
+
+            return resolve({
+                tradeProfit: Math.round(tradeProfit + fromPrevious.made),
+                overpriceProfit: Math.round(overpriceProfit + fromPrevious.overpay),
+                since: !timeSince ? 0 : now.diff(dayjs.unix(timeSince), 'day'),
+                profitTimed: Math.round(profitTimed)
+            });
+        } else {
+            const fromPrevious = {
+                made: Currencies.toScrap(bot.options.statistics.lastTotalProfitMadeInRef),
+                overpay: Currencies.toScrap(bot.options.statistics.lastTotalProfitOverpayInRef),
+                since: bot.options.statistics.profitDataSinceInUnix
+            };
+
+            const timeSince = fromPrevious.since === 0 ? undefined : fromPrevious.since;
+
+            return resolve({
+                tradeProfit: Math.round(fromPrevious.made),
+                overpriceProfit: Math.round(fromPrevious.overpay),
+                since: !timeSince ? 0 : now.diff(dayjs.unix(timeSince), 'day'),
+                profitTimed: 0 /* carry from previous somehow */
+            });
         }
-
-        const fromPrevious = {
-            made: Currencies.toScrap(bot.options.statistics.lastTotalProfitMadeInRef),
-            overpay: Currencies.toScrap(bot.options.statistics.lastTotalProfitOverpayInRef)
-        };
-
-        return {
-            tradeProfit: Math.round(tradeProfit + fromPrevious.made),
-            overpriceProfit: Math.round(overpriceProfit + fromPrevious.overpay),
-            since: !timeSince ? 0 : now.diff(dayjs.unix(timeSince), 'day'),
-            profitTimed: Math.round(profitTimed)
-        };
-    } else {
-        const fromPrevious = {
-            made: Currencies.toScrap(bot.options.statistics.lastTotalProfitMadeInRef),
-            overpay: Currencies.toScrap(bot.options.statistics.lastTotalProfitOverpayInRef),
-            since: bot.options.statistics.profitDataSinceInUnix
-        };
-
-        const timeSince = fromPrevious.since === 0 ? undefined : fromPrevious.since;
-
-        return {
-            tradeProfit: Math.round(fromPrevious.made),
-            overpriceProfit: Math.round(fromPrevious.overpay),
-            since: !timeSince ? 0 : now.diff(dayjs.unix(timeSince), 'day'),
-            profitTimed: 0 /* carry from previous somehow */
-        };
-    }
+    });
 }
 
 /**


### PR DESCRIPTION
## Changed
- `!stats` or `!statsdw` commands:
    - ✅ include Mann Co. Supply Crate Key in profit calculation
    - 🔄 use async on profit function
- `!itemstats` command:
    - ✅ support stats for Mann Co. Supply Crate Key
    - 🎨 add a title
    - ✨💰 net profit on a specific item (#356)

## Fixed
- giving price to INVALID_ITEMS (if your `offerReceived.invalidItems.givePrice` is set to `true`:
    - 🐛 fix still pricing crates/cases (again)
    - 🚫 never givePrice to Noise Maker - Winter Holiday