### PR TITLE
v3.4.5

### DIFF
--- a/src/classes/Commands/sub-classes/Status.ts
+++ b/src/classes/Commands/sub-classes/Status.ts
@@ -186,7 +186,7 @@ export default class StatusCommands {
                             metal: +keysAndMetal[1]
                         });
 
-                        totalBoughtValue += sale.toValue(keyPrice);
+                        totalBoughtValue += sale.toValue(keyPrice) * boughtCount;
 
                         acc += sale.toString();
 
@@ -264,7 +264,7 @@ export default class StatusCommands {
                             metal: +keysAndMetal[1]
                         });
 
-                        totalSoldValue += sale.toValue(keyPrice);
+                        totalSoldValue += sale.toValue(keyPrice) * soldCount;
 
                         acc += sale.toString();
                         return acc + '\n';


### PR DESCRIPTION
- `!itemstats` command:
    - 🔨 fix not multiply by bought/sold count
    
![image](https://user-images.githubusercontent.com/47635037/108622183-fd04aa80-7471-11eb-8997-a459252cb53f.png)
