### PR TITLE
[fix] Build images only for Node.js LTS

### DIFF
--- a/.github/workflows/docker-commit.yml
+++ b/.github/workflows/docker-commit.yml
@@ -19,12 +19,11 @@ jobs:
     strategy:
       matrix:
         node:
-          - 15.10-alpine
-          - 15.10-buster
-          - 15.10-buster-slim
-          - 15.10-stretch
-          - 15.10-stretch-slim
-          - lts-alpine
+          - 14.16.0-alpine
+          - 14.16.0-buster
+          - 14.16.0-buster-slim
+          - 14.16.0-stretch
+          - 14.16.0-stretch-slim
 
     name: Tag Commit (node:${{ matrix.node }})
 

--- a/.github/workflows/docker-latest-tag.yml
+++ b/.github/workflows/docker-latest-tag.yml
@@ -21,12 +21,11 @@ jobs:
     strategy:
       matrix:
         node:
-          - 15.10-alpine
-          - 15.10-buster
-          - 15.10-buster-slim
-          - 15.10-stretch
-          - 15.10-stretch-slim
-          - lts-alpine
+          - 14.16.0-alpine
+          - 14.16.0-buster
+          - 14.16.0-buster-slim
+          - 14.16.0-stretch
+          - 14.16.0-stretch-slim
 
     name: Tag Latest (node:${{ matrix.node }})
 

--- a/.github/workflows/docker-release.tag.yml
+++ b/.github/workflows/docker-release.tag.yml
@@ -14,12 +14,11 @@ jobs:
     strategy:
       matrix:
         node:
-          - 15.10-alpine
-          - 15.10-buster
-          - 15.10-buster-slim
-          - 15.10-stretch
-          - 15.10-stretch-slim
-          - lts-alpine
+          - 14.16.0-alpine
+          - 14.16.0-buster
+          - 14.16.0-buster-slim
+          - 14.16.0-stretch
+          - 14.16.0-stretch-slim
 
     name: Tag Release (node:${{ matrix.node }})
 


### PR DESCRIPTION
I quickly realized that 15.10 should not be used since it's not LTS and `lts-alpine` is LTS. I decided to change the Docker images build for LTS only.