### PR TITLE
[readme] Docker badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A free and open source fully automated TF2 trading bot advertising on www.backpa
 
 ![GitHub package version](https://img.shields.io/github/package-json/v/idinium96/tf2autobot.svg)
 [![Build Status](https://img.shields.io/github/workflow/status/idinium96/tf2autobot/CI/development)](https://github.com/idinium96/tf2autobot/actions)
+[![Docker Build Status](https://img.shields.io/github/workflow/status/idinium96/tf2autobot/Docker/development?label=docker%20build)](https://github.com/idinium96/tf2autobot/actions)
 [![GitHub issues](https://img.shields.io/github/issues/idinium96/tf2autobot)](https://github.com/idinium96/tf2autobot/issues)
 [![GitHub forks](https://img.shields.io/github/forks/idinium96/tf2autobot)](https://github.com/idinium96/tf2autobot/network/members)
 [![GitHub stars](https://img.shields.io/github/stars/idinium96/tf2autobot)](https://github.com/idinium96/tf2autobot/stargazers)


### PR DESCRIPTION
I have added a `docker build` badge for the `Docker` CI workflow. Might add more later in the process after v3.5.0.

![Untitled](https://user-images.githubusercontent.com/21983456/109395321-671ac500-7934-11eb-96be-963003f768bc.png)
