### PR TITLE
[3.x] Exclude SIGTERM from crash handle

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -59,7 +59,7 @@ import { XMLHttpRequest } from 'xmlhttprequest-ts';
 import { uptime } from './lib/tools/time';
 
 ON_DEATH({ uncaughtException: true })((signalOrErr, origin) => {
-    const crashed = signalOrErr !== 'SIGINT';
+    const crashed = ['SIGINT', 'SIGTERM'].indexOf(signalOrErr) === -1;
 
     if (crashed) {
         const botReady = botManager.isBotReady;

--- a/src/app.ts
+++ b/src/app.ts
@@ -59,7 +59,7 @@ import { XMLHttpRequest } from 'xmlhttprequest-ts';
 import { uptime } from './lib/tools/time';
 
 ON_DEATH({ uncaughtException: true })((signalOrErr, origin) => {
-    const crashed = ['SIGINT', 'SIGTERM'].indexOf(signalOrErr) === -1;
+    const crashed = ['SIGINT', 'SIGTERM'].indexOf(signalOrErr as 'SIGINT' | 'SIGTERM' | 'SIGQUIT') === -1;
 
     if (crashed) {
         const botReady = botManager.isBotReady;


### PR DESCRIPTION
Both SIGINT and SIGTERM manifest the same way (almost the same way; SIGKILL cannot be caught, tho), so I assume it can be caught too. Many OSes send `SIGINT` and after a certain period of time (depending on the executor) sends SIGTERM, then SIGKILL to kill the process.

It would be nice to have `SIGTERM` too because it helps on any OS to handle crashes like this.