### PR TITLE
💱 partial price on `isPartialPriced` group

### DIFF
--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -740,8 +740,9 @@ export default class Pricelist extends EventEmitter {
 
                                 const isNegativeDiff = newSellValue - currBuyingValue < 0;
 
-                                if (isNegativeDiff) {
+                                if (isNegativeDiff || currPrice.group === 'isPartialPriced') {
                                     // Only trigger this if difference of new selling price and current buying price is negative
+                                    // Or item group is "isPartialPriced".
 
                                     if (newBuyValue < currSellingValue) {
                                         // if new buying price is less than current selling price
@@ -872,8 +873,9 @@ export default class Pricelist extends EventEmitter {
 
                 const isNegativeDiff = newSellValue - currBuyingValue < 0;
 
-                if (isNegativeDiff) {
+                if (isNegativeDiff || match.group === 'isPartialPriced') {
                     // Only trigger this if difference of new selling price and current buying price is negative
+                    // Or item group is "isPartialPriced".
 
                     let isUpdate = false;
 


### PR DESCRIPTION
update on partial price feature:
- partially price an item if newSelling - currentBuying < 0 OR item group is "isPartialPriced".