### PR TITLE
Add option toggle autoAddInvalidUnusual = false

### DIFF
--- a/src/classes/MyHandler/offer/accepted/updateListings.ts
+++ b/src/classes/MyHandler/offer/accepted/updateListings.ts
@@ -30,6 +30,7 @@ export default function updateListings(
     const inventory = bot.inventoryManager.getInventory;
     const hv = highValue.items;
     const normalizePainted = opt.normalize.painted;
+    const dwEnabled = opt.discordWebhook.sendAlert.enable && opt.discordWebhook.sendAlert.url !== '';
 
     for (const sku in diff) {
         if (!Object.prototype.hasOwnProperty.call(diff, sku)) {
@@ -71,11 +72,19 @@ export default function updateListings(
             !isAdmin &&
             opt.pricelist.autoAddInvalidItems.enable;
 
-        const receivedNotInPricelist =
+        const receivedHighValueNotInPricelist =
             !existInPricelist &&
             isNotPureOrWeapons &&
             isNotSkinsOrWarPaint && // exclude War Paint (could be skins)
             isDisabledHV && // This is the only difference
+            !isAdmin;
+
+        const receivedUnusualNotInPricelist =
+            !existInPricelist &&
+            isNotPureOrWeapons &&
+            isNotSkinsOrWarPaint &&
+            item.quality === 5 &&
+            opt.pricelist.autoAddInvalidUnusual === false &&
             !isAdmin;
 
         const isAutoDisableHighValueItems =
@@ -173,7 +182,7 @@ export default function updateListings(
                     log.debug(msg);
 
                     if (opt.sendAlert.enable && opt.sendAlert.autoAddPaintedItems) {
-                        if (opt.discordWebhook.sendAlert.enable && opt.discordWebhook.sendAlert.url !== '') {
+                        if (dwEnabled) {
                             sendAlert('autoAddPaintedItems', bot, msg.replace(/"/g, '`'));
                         } else {
                             bot.messageAdmins(msg, []);
@@ -188,7 +197,7 @@ export default function updateListings(
                     log.debug(msg);
 
                     if (opt.sendAlert.enable && opt.sendAlert.autoAddPaintedItems) {
-                        if (opt.discordWebhook.sendAlert.enable && opt.discordWebhook.sendAlert.url !== '') {
+                        if (dwEnabled) {
                             sendAlert('autoAddPaintedItemsFailed', bot, msg.replace(/"/g, '`'));
                         } else {
                             bot.messageAdmins(msg, []);
@@ -216,7 +225,7 @@ export default function updateListings(
                     log.warn(`❌ Failed to add ${name} (${sku}) sell automatically: ${(err as Error).message}`)
                 );
             //
-        } else if (receivedNotInPricelist) {
+        } else if (receivedHighValueNotInPricelist) {
             // if the item sku is not in pricelist, not craftweapons or pure or skins AND it's a highValue items, and not
             // from ADMINS, then notify admin.
             let msg =
@@ -231,8 +240,22 @@ export default function updateListings(
             }
 
             if (opt.sendAlert.enable && opt.sendAlert.highValue.receivedNotInPricelist) {
-                if (opt.discordWebhook.sendAlert.enable && opt.discordWebhook.sendAlert.url !== '') {
+                if (dwEnabled) {
                     sendAlert('highValuedInvalidItems', bot, msg.replace(/"/g, '`'));
+                } else {
+                    bot.messageAdmins(msg, []);
+                }
+            }
+        } else if (receivedUnusualNotInPricelist) {
+            // if the item sku is not in pricelist, not craftweapons or pure or skins AND it's a Unusual (bought with Generic Unusual), and not
+            // from ADMINS, and opt.pricelist.autoAddInvalidUnusual is false, then notify admin.
+            const msg =
+                'I have received an Unusual bought with Generic Unusual feature\n\nItem info: ' +
+                (dwEnabled ? `[${name}](https://www.prices.tf/items/${sku}) (${sku})` : `${name} (${sku})`);
+
+            if (opt.sendAlert.enable && opt.sendAlert.receivedUnusualNotInPricelist) {
+                if (dwEnabled) {
+                    sendAlert('unusualInvalidItems', bot, msg.replace(/"/g, '`'));
                 } else {
                     bot.messageAdmins(msg, []);
                 }
@@ -280,7 +303,7 @@ export default function updateListings(
                     }
 
                     if (opt.sendAlert.enable && opt.sendAlert.highValue.gotDisabled) {
-                        if (opt.discordWebhook.sendAlert.enable && opt.discordWebhook.sendAlert.url !== '') {
+                        if (dwEnabled) {
                             sendAlert('highValuedDisabled', bot, msg.replace(/"/g, '`'));
                         } else {
                             bot.messageAdmins(msg, []);
@@ -302,7 +325,7 @@ export default function updateListings(
                     log.warn(msg);
 
                     if (opt.sendAlert.enable && opt.sendAlert.autoRemoveIntentSellFailed) {
-                        if (opt.discordWebhook.sendAlert.enable && opt.discordWebhook.sendAlert.url !== '') {
+                        if (dwEnabled) {
                             sendAlert('autoRemoveIntentSellFailed', bot, msg);
                         } else {
                             bot.messageAdmins(msg, []);
@@ -341,7 +364,7 @@ export default function updateListings(
                     log.debug(msg);
 
                     if (opt.sendAlert.enable && opt.sendAlert.partialPrice.onSuccessUpdatePartialPriced) {
-                        if (opt.discordWebhook.sendAlert.enable && opt.discordWebhook.sendAlert.url !== '') {
+                        if (dwEnabled) {
                             sendAlert('autoUpdatePartialPriceSuccess', bot, msg);
                         } else {
                             bot.messageAdmins('✅ Automatically update partially priced item - ' + msg, []);
@@ -353,7 +376,7 @@ export default function updateListings(
                     log.warn(msg);
 
                     if (opt.sendAlert.enable && opt.sendAlert.partialPrice.onFailedUpdatePartialPriced) {
-                        if (opt.discordWebhook.sendAlert.enable && opt.discordWebhook.sendAlert.url !== '') {
+                        if (dwEnabled) {
                             sendAlert('autoUpdatePartialPriceFailed', bot, msg);
                         } else {
                             bot.messageAdmins(msg, []);

--- a/src/classes/MyHandler/offer/accepted/updateListings.ts
+++ b/src/classes/MyHandler/offer/accepted/updateListings.ts
@@ -44,6 +44,9 @@ export default function updateListings(
         const isDisabledHV = highValue.isDisableSKU.includes(sku);
         const isAdmin = bot.isAdmin(offer.partner);
         const isNotSkinsOrWarPaint = SKU.fromString(sku).wear === null;
+        // if item is unusual and autoAddInvalidUnusual is set to true then we allow addInvalidUnusual.
+        // If the item is not an unusual sku, we "allow" still (no-op)
+        const addInvalidUnusual = SKU.fromString(sku).quality === 5 ? opt.pricelist.autoAddInvalidUnusual : true;
 
         const isAutoaddPainted =
             normalizePainted.our === false && // must meet this setting
@@ -62,6 +65,7 @@ export default function updateListings(
             isNotPureOrWeapons &&
             sku !== '5021;6' && // not Mann Co. Supply Crate Key
             isNotSkinsOrWarPaint && // exclude War Paint (could be skins)
+            addInvalidUnusual &&
             !isDisabledHV &&
             !isAdmin &&
             opt.pricelist.autoAddInvalidItems.enable;

--- a/src/classes/MyHandler/offer/accepted/updateListings.ts
+++ b/src/classes/MyHandler/offer/accepted/updateListings.ts
@@ -36,17 +36,18 @@ export default function updateListings(
             continue;
         }
 
-        const name = bot.schema.getName(SKU.fromString(sku), false);
+        const item = SKU.fromString(sku);
+        const name = bot.schema.getName(item, false);
         const isNotPureOrWeapons = !(weapons.includes(sku) || ['5000;6', '5001;6', '5002;6'].includes(sku));
         const inPrice = bot.pricelist.getPrice(sku, false);
 
         const existInPricelist = inPrice !== null;
         const isDisabledHV = highValue.isDisableSKU.includes(sku);
         const isAdmin = bot.isAdmin(offer.partner);
-        const isNotSkinsOrWarPaint = SKU.fromString(sku).wear === null;
+        const isNotSkinsOrWarPaint = item.wear === null;
         // if item is unusual and autoAddInvalidUnusual is set to true then we allow addInvalidUnusual.
         // If the item is not an unusual sku, we "allow" still (no-op)
-        const addInvalidUnusual = SKU.fromString(sku).quality === 5 ? opt.pricelist.autoAddInvalidUnusual : true;
+        const addInvalidUnusual = item.quality === 5 ? opt.pricelist.autoAddInvalidUnusual : true;
 
         const isAutoaddPainted =
             normalizePainted.our === false && // must meet this setting

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -83,7 +83,7 @@ export const DEFAULTS = {
         autoAddInvalidItems: {
             enable: true
         },
-        addInvalidUnusual: {
+        autoAddInvalidUnusual: {
             enable: false
         },
         autoAddPaintedItems: {

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -66,7 +66,8 @@ export const DEFAULTS = {
             onUpdate: true,
             onSuccessUpdatePartialPriced: true,
             onFailedUpdatePartialPriced: true
-        }
+        },
+        receivedUnusualNotInPricelist: true
     },
 
     pricelist: {
@@ -1027,6 +1028,7 @@ interface SendAlert extends OnlyEnable {
     failedAccept?: boolean;
     unableToProcessOffer?: boolean;
     partialPrice?: PartialPrice;
+    receivedUnusualNotInPricelist?: boolean;
 }
 
 interface PartialPrice {

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -83,6 +83,9 @@ export const DEFAULTS = {
         autoAddInvalidItems: {
             enable: true
         },
+        addInvalidUnusual: {
+            enable: false
+        },
         autoAddPaintedItems: {
             enable: true
         },
@@ -1052,6 +1055,7 @@ interface Pricelist {
     filterCantAfford?: OnlyEnable;
     autoRemoveIntentSell?: OnlyEnable;
     autoAddInvalidItems?: OnlyEnable;
+    autoAddInvalidUnusual?: OnlyEnable;
     autoAddPaintedItems?: OnlyEnable;
     priceAge?: PriceAge;
 }

--- a/src/lib/DiscordWebhook/sendAlert.ts
+++ b/src/lib/DiscordWebhook/sendAlert.ts
@@ -36,7 +36,8 @@ type AlertType =
     | 'error-accept'
     | 'autoUpdatePartialPriceSuccess'
     | 'autoUpdatePartialPriceFailed'
-    | 'isPartialPriced';
+    | 'isPartialPriced'
+    | 'unusualInvalidItems';
 
 export default function sendAlert(
     type: AlertType,
@@ -105,6 +106,10 @@ export default function sendAlert(
         color = '8323327'; // purple
     } else if (type === 'highValuedInvalidItems') {
         title = 'Received High-value invalid item(s)';
+        description = msg;
+        color = '8323327'; // purple
+    } else if (type === 'unusualInvalidItems') {
+        title = 'Received Unusual bought with Generic Unusual feature';
         description = msg;
         color = '8323327'; // purple
     } else if (type === 'autoRemoveIntentSellFailed') {
@@ -217,7 +222,8 @@ export default function sendAlert(
                 'queue-problem-not-restart-bptf-down',
                 'autoAddPaintedItemsFailed',
                 'failed-accept',
-                'error-accept'
+                'error-accept',
+                'unusualInvalidItems'
             ].includes(type) && optDW.sendAlert.isMention
                 ? `<@!${optDW.ownerID}>`
                 : '') + (content ? ` - ${content}` : ''),

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -523,6 +523,9 @@ export const optionsSchema: jsonschema.Schema = {
                 autoAddInvalidItems: {
                     $ref: '#/definitions/only-enable'
                 },
+                autoAddInvalidUnusual: {
+                    $ref: '#/definitions/only-enable'
+                },
                 autoAddPaintedItems: {
                     $ref: '#/definitions/only-enable'
                 },
@@ -543,6 +546,7 @@ export const optionsSchema: jsonschema.Schema = {
                 'filterCantAfford',
                 'autoRemoveIntentSell',
                 'autoAddInvalidItems',
+                'autoAddInvalidUnusual',
                 'autoAddPaintedItems',
                 'priceAge'
             ],

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -482,6 +482,9 @@ export const optionsSchema: jsonschema.Schema = {
                     },
                     required: ['onUpdate', 'onSuccessUpdatePartialPriced', 'onFailedUpdatePartialPriced'],
                     additionalProperties: false
+                },
+                receivedUnusualNotInPricelist: {
+                    type: 'boolean'
                 }
             },
             required: [
@@ -493,7 +496,8 @@ export const optionsSchema: jsonschema.Schema = {
                 'autoAddPaintedItems',
                 'failedAccept',
                 'unableToProcessOffer',
-                'partialPrice'
+                'partialPrice',
+                'receivedUnusualNotInPricelist'
             ],
             additionalProperties: false
         },


### PR DESCRIPTION
If the bot accepts an Unusual item that is not on the price list it will not put it back up for sale unless autoAddInvalidUnusual is set to true. The option is set to false by default to protect users who use the generic price SKU and unaware that autoAddInvalidItems would sell off anything purchased via that generic sku.

Based off conversation in #400