### PR TITLE
🔕 ignore some error on fail action or to accept

### DIFF
--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -540,7 +540,7 @@ export default class Trades {
                         log.debug(`Error while trying to accept mobile confirmation on offer #${offer.id}: `, err);
 
                         const isNotIgnoredError =
-                            !(err as CustomError).message?.includes('Could not act on confirmation') ||
+                            !(err as CustomError).message?.includes('Could not act on confirmation') &&
                             !(err as CustomError).message?.includes('Could not find confirmation for object');
 
                         if (isNotIgnoredError) {

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -328,57 +328,65 @@ export default class Trades {
             .catch(err => {
                 log.warn(`Failed to ${action} on the offer #${offer.id}: `, err);
 
-                const opt = this.bot.options;
-                if (opt.sendAlert.failedAccept) {
-                    const keyPrices = this.bot.pricelist.getKeyPrices;
-                    const value = t.valueDiff(offer, keyPrices, false, opt.miscSettings.showOnlyMetal.enable);
+                /* Ignore notifying admin if eresult is "AlreadyRedeemed" or "InvalidState", or if the message includes that */
+                const isNotInvalidStates = (err as CustomError).eresult
+                    ? ![11, 28].includes((err as CustomError).eresult)
+                    : !(err as CustomError).message.includes('is not active, so it may not be accepted');
 
-                    if (opt.discordWebhook.sendAlert.enable && opt.discordWebhook.sendAlert.url !== '') {
-                        const summary = t.summarizeToChat(
-                            offer,
-                            this.bot,
-                            'summary-accepting',
-                            true,
-                            value,
-                            keyPrices,
-                            false,
-                            false
-                        );
-                        sendAlert(
-                            `failed-${action}` as 'failed-accept' | 'failed-decline',
-                            this.bot,
-                            `Failed to ${action} on the offer #${offer.id}` +
-                                summary +
-                                `\n\nRetrying in 30 seconds, or you can try to force ${action} this trade, send "!f${action} ${offer.id}" now.`,
-                            null,
-                            err,
-                            [offer.id]
-                        );
-                    } else {
-                        const summary = t.summarizeToChat(
-                            offer,
-                            this.bot,
-                            'summary-accepting',
-                            false,
-                            value,
-                            keyPrices,
-                            true,
-                            false
-                        );
+                if (isNotInvalidStates) {
+                    const opt = this.bot.options;
 
-                        this.bot.messageAdmins(
-                            `Failed to ${action} on the offer #${offer.id}:` +
-                                summary +
-                                `\n\nRetrying in 30 seconds, you can try to force ${action} this trade, reply "!f${action} ${offer.id}" now.` +
-                                `\n\nError: ${
-                                    (err as CustomError).eresult
-                                        ? `${
-                                              TradeOfferManager.EResult[(err as CustomError).eresult] as string
-                                          } - https://steamerrors.com/${(err as CustomError).eresult}`
-                                        : JSON.stringify(err, null, 4)
-                                }`,
-                            []
-                        );
+                    if (opt.sendAlert.failedAccept) {
+                        const keyPrices = this.bot.pricelist.getKeyPrices;
+                        const value = t.valueDiff(offer, keyPrices, false, opt.miscSettings.showOnlyMetal.enable);
+
+                        if (opt.discordWebhook.sendAlert.enable && opt.discordWebhook.sendAlert.url !== '') {
+                            const summary = t.summarizeToChat(
+                                offer,
+                                this.bot,
+                                'summary-accepting',
+                                true,
+                                value,
+                                keyPrices,
+                                false,
+                                false
+                            );
+                            sendAlert(
+                                `failed-${action}` as 'failed-accept' | 'failed-decline',
+                                this.bot,
+                                `Failed to ${action} on the offer #${offer.id}` +
+                                    summary +
+                                    `\n\nRetrying in 30 seconds, or you can try to force ${action} this trade, send "!f${action} ${offer.id}" now.`,
+                                null,
+                                err,
+                                [offer.id]
+                            );
+                        } else {
+                            const summary = t.summarizeToChat(
+                                offer,
+                                this.bot,
+                                'summary-accepting',
+                                false,
+                                value,
+                                keyPrices,
+                                true,
+                                false
+                            );
+
+                            this.bot.messageAdmins(
+                                `Failed to ${action} on the offer #${offer.id}:` +
+                                    summary +
+                                    `\n\nRetrying in 30 seconds, you can try to force ${action} this trade, reply "!f${action} ${offer.id}" now.` +
+                                    `\n\nError: ${
+                                        (err as CustomError).eresult
+                                            ? `${
+                                                  TradeOfferManager.EResult[(err as CustomError).eresult] as string
+                                              } - https://steamerrors.com/${(err as CustomError).eresult}`
+                                            : (err as Error).message
+                                    }`,
+                                []
+                            );
+                        }
                     }
                 }
 
@@ -527,10 +535,14 @@ export default class Trades {
                     this.acceptConfirmation(offer).catch(err => {
                         log.debug(`Error while trying to accept mobile confirmation on offer #${offer.id}: `, err);
 
-                        if (!(err as CustomError).message?.includes('Could not act on confirmation')) {
-                            // Only notify is error is not "Could not act on confirmation"
+                        const isNotIgnoredError =
+                            !(err as CustomError).message?.includes('Could not act on confirmation') ||
+                            !(err as CustomError).message?.includes('Could not find confirmation for object');
 
+                        if (isNotIgnoredError) {
+                            // Only notify if error is not "Could not act on confirmation" or not "Could not find confirmation for object"
                             const opt = this.bot.options;
+
                             if (opt.sendAlert.failedAccept) {
                                 const keyPrices = this.bot.pricelist.getKeyPrices;
                                 const value = t.valueDiff(
@@ -592,6 +604,11 @@ export default class Trades {
                                     );
                                 }
                             }
+
+                            setTimeout(() => {
+                                // Auto-retry after 30 seconds
+                                void this.retryActionAfterFailure(offer.id, 'accept');
+                            }, 30 * 1000);
                         }
                     });
                 }


### PR DESCRIPTION
- On failed action (accept/decline):
    - Ignore sending a notification to admin/Discord Webhook if the `eresult` error is "AlreadyRedeemed" or "InvalidState", and if the error message includes "is not active, so it may not be accepted", but the bot will still retry to accept after 30 seconds in the background.

- On failed to error while trying to accept mobile confirmation:
    - Ignore sending a notification to admin/Discord Webhook and do not perform auto-retry if the error message includes "Could not act on confirmation" or "Could not find confirmation for object"