### PR TITLE
patch - v3.6.2

### DIFF
--- a/src/lib/tools/summarizeOffer.ts
+++ b/src/lib/tools/summarizeOffer.ts
@@ -192,7 +192,7 @@ function getSummary(
                             : name
                     }](https://www.prices.tf/items/${sku})${amount > 1 ? ` x${amount}` : ''} (${
                         notForPartner && oldStock !== null ? `${oldStock} → ` : ''
-                    }${currentStock}${maxStock ? `/${maxStock.max}` : ''})`
+                    }${currentStock === 0 ? amount : currentStock}${maxStock ? `/${maxStock.max}` : ''})`
                 );
             } else {
                 summary.push(

--- a/src/lib/tools/summarizeOffer.ts
+++ b/src/lib/tools/summarizeOffer.ts
@@ -177,7 +177,7 @@ function getSummary(
             const notForPartner = ['summary-accepted', 'review-admin', 'summary-accepting'].includes(type);
 
             if (notForPartner) {
-                oldStock = which === 'our' ? currentStock + amount : currentStock - amount;
+                oldStock = which === 'our' ? currentStock + amount : currentStock === 0 ? 0 : currentStock - amount;
             } else {
                 oldStock = currentStock;
             }


### PR DESCRIPTION
- Stock changes (only if you have `tradeSummary.showStockChanges` set to `true`)
    - 🔨 fix a negative value on their side (offer review and logs) - @idinium96

![image](https://user-images.githubusercontent.com/47635037/110226294-e60d9000-7f28-11eb-829c-86f11a15a45f.png)
![image](https://user-images.githubusercontent.com/47635037/110226311-05a4b880-7f29-11eb-9a9e-173a634616c3.png)
