### PR TITLE
✨ add an option to not show owner's nickname

### DIFF
--- a/src/classes/Commands/sub-classes/Message.ts
+++ b/src/classes/Commands/sub-classes/Message.ts
@@ -64,14 +64,18 @@ export default class MessageCommand {
             }
 
             const recipientDetails = this.bot.friends.getFriend(recipientSteamID);
+            const adminDetails = this.bot.friends.getFriend(steamID);
             const reply = steamIdAndMessage.substr(steamIDString.length);
+            const isShowOwner = this.bot.options.commands.message.showOwnerName;
 
             // Send message to recipient
             this.bot.sendMessage(
                 recipientSteamID,
                 custom.fromOwner
                     ? custom.fromOwner.replace(/%reply%/g, reply)
-                    : `/quote 💬 Message from the owner: ${reply}` +
+                    : `/quote 💬 Message from ${
+                          isShowOwner && adminDetails ? adminDetails.player_name : 'the owner'
+                      }: ${reply}` +
                           '\n\n❔ Hint: You can use the !message command to respond to the owner of this bot.' +
                           '\nExample: !message Hi Thanks!'
             );

--- a/src/classes/Commands/sub-classes/Review.ts
+++ b/src/classes/Commands/sub-classes/Review.ts
@@ -263,9 +263,13 @@ export default class ReviewCommands {
 
                 // Send message to recipient if includes some messages
                 if (reply) {
+                    const isShowOwner = this.bot.options.commands.message.showOwnerName;
+
                     this.bot.sendMessage(
                         partnerId,
-                        `/quote 💬 Message from ${adminDetails ? adminDetails.player_name : 'admin'}: ${reply}`
+                        `/quote 💬 Message from ${
+                            isShowOwner && adminDetails ? adminDetails.player_name : 'the owner'
+                        }: ${reply}`
                     );
                 }
             } catch (err) {
@@ -324,9 +328,13 @@ export default class ReviewCommands {
 
                 // Send message to recipient if includes some messages
                 if (reply) {
+                    const isShowOwner = this.bot.options.commands.message.showOwnerName;
+
                     this.bot.sendMessage(
                         partnerId,
-                        `/quote 💬 Message from ${adminDetails ? adminDetails.player_name : 'admin'}: ${reply}`
+                        `/quote 💬 Message from ${
+                            isShowOwner && adminDetails ? adminDetails.player_name : 'the owner'
+                        }: ${reply}`
                     );
                 }
             } catch (err) {

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -600,6 +600,7 @@ export const DEFAULTS = {
         },
         message: {
             enable: true,
+            showOwnerName: true,
             customReply: {
                 disabled: '',
                 wrongSyntax: '',
@@ -1558,6 +1559,7 @@ interface AutokeysCommand extends OnlyEnable {
 }
 
 interface Message extends OnlyEnable {
+    showOwnerName?: boolean;
     customReply?: MessageCustom;
 }
 

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -1628,6 +1628,9 @@ export const optionsSchema: jsonschema.Schema = {
                         enable: {
                             type: 'boolean'
                         },
+                        showOwnerName: {
+                            type: 'boolean'
+                        },
                         customReply: {
                             type: 'object',
                             properties: {
@@ -1648,7 +1651,7 @@ export const optionsSchema: jsonschema.Schema = {
                             additionalProperties: false
                         }
                     },
-                    required: ['enable', 'customReply'],
+                    required: ['enable', 'showOwnerName', 'customReply'],
                     additionalProperties: false
                 },
                 time: {


### PR DESCRIPTION
Option to hide owner's nickname on `!message` & `!accept`/`!decline`(if reply is included) commands.
Default is true (show nickname).