### PR TITLE
🚧 add failsafe on updateOldPrices method

### DIFF
--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -67,7 +67,8 @@ export const DEFAULTS = {
             onSuccessUpdatePartialPriced: true,
             onFailedUpdatePartialPriced: true
         },
-        receivedUnusualNotInPricelist: true
+        receivedUnusualNotInPricelist: true,
+        failedToUpdateOldPrices: true
     },
 
     pricelist: {
@@ -1034,6 +1035,7 @@ interface SendAlert extends OnlyEnable {
     unableToProcessOffer?: boolean;
     partialPrice?: PartialPrice;
     receivedUnusualNotInPricelist?: boolean;
+    failedToUpdateOldPrices?: boolean;
 }
 
 interface PartialPrice {

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -777,11 +777,9 @@ export default class Pricelist extends EventEmitter {
                 try {
                     grouped = groupedPrices[item.quality][item.killstreak];
                 } catch (err) {
-                    const index = this.getIndex(sku);
-
-                    if (this.prices[index].group !== 'failed-updateOldPrices') {
-                        this.prices[index].enabled = false;
-                        this.prices[index].group = 'failed-updateOldPrices';
+                    if (currPrice.group !== 'failed-updateOldPrices') {
+                        currPrice.enabled = false;
+                        currPrice.group = 'failed-updateOldPrices';
                         this.failedUpdateOldPrices.push(sku);
                         log.warn(`updateOldPrices failed for ${sku}`, err);
                         pricesChanged = true;

--- a/src/lib/DiscordWebhook/sendAlert.ts
+++ b/src/lib/DiscordWebhook/sendAlert.ts
@@ -37,7 +37,8 @@ type AlertType =
     | 'autoUpdatePartialPriceSuccess'
     | 'autoUpdatePartialPriceFailed'
     | 'isPartialPriced'
-    | 'unusualInvalidItems';
+    | 'unusualInvalidItems'
+    | 'failedToUpdateOldPrices';
 
 export default function sendAlert(
     type: AlertType,
@@ -192,6 +193,12 @@ export default function sendAlert(
         title = 'Partial price update';
         description = msg;
         color = '16776960'; // yellow
+    } else if (type === 'failedToUpdateOldPrices') {
+        title = 'Failed to update old prices';
+        description =
+            `Failed to update old prices (probably because autoprice is set to true but item does not exist` +
+            ` on the pricer source):\n\n${items.join('\n')}\n\nAll items above has been temporarily disabled.`;
+        color = '16711680'; // red
     } else {
         title = 'High Valued Items';
         description = `Someone is trying to take your **${items.join(', ')}** that is not in your pricelist.`;

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -485,6 +485,9 @@ export const optionsSchema: jsonschema.Schema = {
                 },
                 receivedUnusualNotInPricelist: {
                     type: 'boolean'
+                },
+                failedToUpdateOldPrices: {
+                    type: 'boolean'
                 }
             },
             required: [


### PR DESCRIPTION
Mostly for custom pricer user, but can also occur if you manually change the `autoprice` property of any item that does not exist in the pricer pricelist, i.e. most skins or some unusual that does not exist in the source pricelist should be manually priced, and then if you edit your `pricelist.json` and change the `autoprice` to `true` (or even if you use `!update all=true&autoprice=true` command), an error will occur here:
https://github.com/TF2Autobot/tf2autobot/blob/43ba1e54c67b444d376b436f034877545191fa53/src/classes/Pricelist.ts#L770

and then your bot will use the temporary "hard-coded" key prices:
https://github.com/TF2Autobot/tf2autobot/blob/43ba1e54c67b444d376b436f034877545191fa53/src/classes/Pricelist.ts#L643-L648

These changes will skip the affected item and temporarily disabled it.

Discovered by @Bonfire

EDIT:
Apparently, this will only occur on a custom autopricer.