### PR TITLE
PPU: 🔨 fix the unintended rare occurrence

### DIFF
--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -797,7 +797,7 @@ export default class Pricelist extends EventEmitter {
                                 const isNegativeDiff = newSellValue - currBuyingValue <= 0;
 
                                 if (isNegativeDiff || currPrice.group === 'isPartialPriced') {
-                                    // Only trigger this if difference of new selling price and current buying price is negative
+                                    // Only trigger this if difference of new selling price and current buying price is negative or zero
                                     // Or item group is "isPartialPriced".
 
                                     if (newBuyValue < currSellingValue) {
@@ -967,7 +967,7 @@ export default class Pricelist extends EventEmitter {
                 const isNegativeDiff = newSellValue - currBuyingValue <= 0;
 
                 if (isNegativeDiff || match.group === 'isPartialPriced') {
-                    // Only trigger this if difference of new selling price and current buying price is negative
+                    // Only trigger this if difference of new selling price and current buying price is negative or zero
                     // Or item group is "isPartialPriced".
 
                     let isUpdate = false;

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -794,7 +794,7 @@ export default class Pricelist extends EventEmitter {
                                 // if optPartialUpdate.enable is true and the item is currently in stock
                                 // and difference between latest time and time recorded in pricelist is less than threshold
 
-                                const isNegativeDiff = newSellValue - currBuyingValue < 0;
+                                const isNegativeDiff = newSellValue - currBuyingValue <= 0;
 
                                 if (isNegativeDiff || currPrice.group === 'isPartialPriced') {
                                     // Only trigger this if difference of new selling price and current buying price is negative
@@ -964,7 +964,7 @@ export default class Pricelist extends EventEmitter {
                 const currBuyingValue = match.buy.toValue(keyPrice);
                 const currSellingValue = match.sell.toValue(keyPrice);
 
-                const isNegativeDiff = newSellValue - currBuyingValue < 0;
+                const isNegativeDiff = newSellValue - currBuyingValue <= 0;
 
                 if (isNegativeDiff || match.group === 'isPartialPriced') {
                     // Only trigger this if difference of new selling price and current buying price is negative


### PR DESCRIPTION
Fix bot does not apply PPU when this occurs:
- The bot bought for 16 keys (which is about ~7552 in scrap value at 52.44 ref/key):
![image](https://user-images.githubusercontent.com/47635037/112474987-3ef37a00-8dab-11eb-8b41-b8971659fa57.png)

- And then the price got updated with 14 keys, 21 ref / 15 keys, 52.44 ref - Which is for the selling price is basically the same as the previous buying price (broken prices.tf 😭).
![image](https://user-images.githubusercontent.com/47635037/112475003-4581f180-8dab-11eb-8592-f05bb1e67041.png)

And thus the item was sold for 0 profit.
![image](https://user-images.githubusercontent.com/47635037/112476303-b970c980-8dac-11eb-9be5-facc64bafa6e.png)
