### PR TITLE
🐛 fix false Autokeys failed to disable error

### DIFF
--- a/src/classes/MyHandler/offer/accepted/updateListings.ts
+++ b/src/classes/MyHandler/offer/accepted/updateListings.ts
@@ -112,6 +112,7 @@ export default function updateListings(
             opt.pricelist.autoRemoveIntentSell.enable &&
             existInPricelist &&
             inPrice.intent === 1 &&
+            (opt.autokeys.enable ? sku !== '5021;6' : true) && // not Mann Co. Supply Crate Key if Autokeys enabled
             inventory.getAmount(sku, true) < 1 && // current stock
             isNotPureOrWeapons;
 


### PR DESCRIPTION
This can occur if your `pricelist.autoRemoveIntentSell.enable` is set to `true`, and also the `autokeys.enable` set to true and Autokeys was active selling and after a trade, the stock for keys goes to 0, which triggered the `autoRemoveIntentSell` first before the disable Autokeys method.

![image](https://user-images.githubusercontent.com/47635037/112608149-f0021f00-8e54-11eb-8f96-01dbf37b7967.png)
![image](https://user-images.githubusercontent.com/47635037/112608282-1d4ecd00-8e55-11eb-9857-b0b9d3488e04.png)
