### PR TITLE
🐛 fix performance issue on start (with huge listings/pricelist)

### DIFF
--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -512,9 +512,9 @@ export default class Pricelist extends EventEmitter {
     }
 
     getIndex(sku: string, parsedSku?: SchemaManager.Item): number {
-        // Get name of item
-        //const name = this.schema.getName(parsedSku ? parsedSku : SKU.fromString(sku), false);
-        return this.prices.findIndex(entry => entry.sku === (sku ? sku : SKU.fromObject(parsedSku)));
+        sku = sku ? sku : SKU.fromObject(parsedSku);
+        const findIndex = this.prices.findIndex(entry => entry.sku === sku);
+        return findIndex;
     }
 
     /** returns index of sku's generic match otherwise returns -1 */


### PR DESCRIPTION
Doing this:
```ts
    return this.prices.findIndex(entry => entry.sku === (sku ? sku : SKU.fromObject(parsedSku)));
```
will make it to poorly perform the task -

![image](https://user-images.githubusercontent.com/47635037/112783572-31c3dd00-9082-11eb-81e1-5eecf5c1dc35.png)

But this:
```ts
    sku = sku ? sku : SKU.fromObject(parsedSku);
    const findIndex = this.prices.findIndex(entry => entry.sku === sku);
    return findIndex;
```
Surprising fast -

![image](https://user-images.githubusercontent.com/47635037/112783792-b1ea4280-9082-11eb-9efb-0b38b3973dc3.png)

This "without delay" thing is just the debugging thing I added here:
https://github.com/TF2Autobot/tf2autobot/blob/b059c6273e849159f65912204bef9ff5631e1060/src/classes/Listings.ts#L399-L425