### PR TITLE
✨ add new "isPartialPriced" key in pricelist entry

### DIFF
--- a/src/classes/Commands/sub-classes/PricelistManager.ts
+++ b/src/classes/Commands/sub-classes/PricelistManager.ts
@@ -161,6 +161,10 @@ export default class PricelistManagerCommands {
             params.autoprice = true;
         }
 
+        if (params.isPartialPriced === undefined) {
+            params.isPartialPriced = false;
+        }
+
         if (params.sku !== undefined && !testSKU(params.sku as string)) {
             return this.bot.sendMessage(steamID, `❌ "sku" should not be empty or wrong format.`);
         }
@@ -201,6 +205,7 @@ export default class PricelistManagerCommands {
             `\n📦 Stock: ${amount} | Min: ${entry.min} | Max: ${entry.max}` +
             `\n📋 Enabled: ${entry.enabled ? '✅' : '❌'}` +
             `\n🔄 Autoprice: ${entry.autoprice ? '✅' : '❌'}` +
+            `\n½🔄 isPartialPriced: ${entry.isPartialPriced ? '✅' : '❌'}` +
             (isPremium ? `\n📢 Promoted: ${entry.promoted === 1 ? '✅' : '❌'}` : '') +
             `\n🔰 Group: ${entry.group}` +
             `${entry.note.buy !== null ? `\n📥 Custom buying note: ${entry.note.buy}` : ''}` +
@@ -632,6 +637,10 @@ export default class PricelistManagerCommands {
                     entry.autoprice = params.autoprice;
                 }
 
+                if (typeof params.isPartialPriced === 'boolean') {
+                    entry.isPartialPriced = params.isPartialPriced;
+                }
+
                 if (params.withgroup || params.withoutgroup) {
                     if (typeof params.note === 'object') {
                         // can change note if have withgroup/withoutgroup parameter
@@ -672,6 +681,7 @@ export default class PricelistManagerCommands {
                             promoted: entry.promoted,
                             group: entry.group,
                             note: entry.note,
+                            isPartialPriced: entry.isPartialPriced,
                             time: entry.time
                         },
                         'pricelist'
@@ -976,6 +986,11 @@ export default class PricelistManagerCommands {
                     ? `${oldEntry.autoprice ? '✅' : '❌'} → ${newEntry.autoprice ? '✅' : '❌'}`
                     : `${newEntry.autoprice ? '✅' : '❌'}`
             }` +
+            `\n½🔄 isPartialPriced: ${
+                oldEntry.isPartialPriced !== newEntry.isPartialPriced
+                    ? `${oldEntry.isPartialPriced ? '✅' : '❌'} → ${newEntry.isPartialPriced ? '✅' : '❌'}`
+                    : `${newEntry.isPartialPriced ? '✅' : '❌'}`
+            }` +
             (isPremium
                 ? `\n📢 Promoted: ${
                       oldEntry.promoted !== newEntry.promoted
@@ -1269,9 +1284,9 @@ export default class PricelistManagerCommands {
 
             return `${i + 1}. ${entry.sku} - ${name}${name.length > 40 ? '\n' : ' '}(${stock}, ${entry.min}, ${
                 entry.max
-            }, ${entry.intent}, ${entry.enabled ? '✅' : '❌'}, ${entry.autoprice ? '✅' : '❌'}${
-                isPremium ? `, ${entry.promoted === 1 ? '✅' : '❌'}, ` : ', '
-            }${entry.group})`;
+            }, ${entry.intent}, ${entry.enabled ? '✅' : '❌'}, ${entry.autoprice ? '✅' : '❌'}, ${entry.group}, ${
+                entry.isPartialPriced ? '✅' : '❌'
+            }${isPremium ? `, ${entry.promoted === 1 ? '✅' : '❌'}` : ''})`;
         });
 
         const listCount = list.length;
@@ -1286,7 +1301,7 @@ export default class PricelistManagerCommands {
                     : `${
                           limit < listCount && limit > 0 && params.limit !== undefined ? ` (limit set to ${limit})` : ''
                       }.`
-            }\n\n 📌 #. "sku" - "name" ("Current Stock", "min", "max", "intent", "enabled", "autoprice", *"promoted", "group")\n\n` +
+            }\n\n 📌 #. "sku" - "name" ("Current Stock", "min", "max", "intent", "enabled", "autoprice", "group", "isPartialPriced", *"promoted")\n\n` +
                 '* - Only shown if your account is Backpack.tf Premium\n\n.'
         );
 
@@ -1315,12 +1330,14 @@ export default class PricelistManagerCommands {
                 params.intent !== undefined ||
                 params.autoprice !== undefined ||
                 params.group !== undefined ||
-                params.promoted !== undefined
+                params.promoted !== undefined ||
+                params.isPartialPriced !== undefined
             )
         ) {
             return this.bot.sendMessage(
                 steamID,
-                '⚠️ Only parameters available for !find command: enabled, max, min, intent, promoted, autoprice or group\nExample: !find intent=bank&max=2'
+                '⚠️ Only parameters available for !find command: enabled, max, min, intent,' +
+                    ' promoted, autoprice, isPartialPriced, or group\nExample: !find intent=bank&max=2'
             );
         }
 
@@ -1332,18 +1349,18 @@ export default class PricelistManagerCommands {
             filter = filter.filter(entry => entry.enabled === params.enabled);
         }
 
-        if (params.max !== undefined) {
-            if (typeof params.max !== 'number') {
-                return this.bot.sendMessage(steamID, '⚠️ max parameter must be an integer');
-            }
-            filter = filter.filter(entry => entry.max === params.max);
-        }
-
         if (params.min !== undefined) {
             if (typeof params.min !== 'number') {
                 return this.bot.sendMessage(steamID, '⚠️ min parameter must be an integer');
             }
             filter = filter.filter(entry => entry.min === params.min);
+        }
+
+        if (params.max !== undefined) {
+            if (typeof params.max !== 'number') {
+                return this.bot.sendMessage(steamID, '⚠️ max parameter must be an integer');
+            }
+            filter = filter.filter(entry => entry.max === params.max);
         }
 
         if (params.promoted !== undefined) {
@@ -1392,6 +1409,13 @@ export default class PricelistManagerCommands {
             filter = filter.filter(entry => entry.autoprice === params.autoprice);
         }
 
+        if (params.isPartialPriced !== undefined) {
+            if (typeof params.isPartialPriced !== 'boolean') {
+                return this.bot.sendMessage(steamID, '⚠️ isPartialPriced parameter must be "true" or "false"');
+            }
+            filter = filter.filter(entry => entry.isPartialPriced === params.isPartialPriced);
+        }
+
         if (params.group !== undefined) {
             if (typeof params.group !== 'string') {
                 return this.bot.sendMessage(steamID, '⚠️ group parameter must be a string');
@@ -1402,8 +1426,12 @@ export default class PricelistManagerCommands {
         const parametersUsed = {
             enabled: params.enabled !== undefined ? `enabled=${(params.enabled as boolean).toString()}` : '',
             autoprice: params.autoprice !== undefined ? `autoprice=${(params.autoprice as boolean).toString()}` : '',
-            max: params.max !== undefined ? `max=${params.max as number}` : '',
+            isPartialPriced:
+                params.isPartialPriced !== undefined
+                    ? `isPartialPriced=${(params.isPartialPriced as boolean).toString()}`
+                    : '',
             min: params.min !== undefined ? `min=${params.min as number}` : '',
+            max: params.max !== undefined ? `max=${params.max as number}` : '',
             intent:
                 params.intent !== undefined
                     ? `intent=${
@@ -1430,9 +1458,9 @@ export default class PricelistManagerCommands {
 
                 return `${i + 1}. ${entry.sku} - ${name}${name.length > 40 ? '\n' : ' '}(${stock}, ${entry.min}, ${
                     entry.max
-                }, ${entry.intent}, ${entry.enabled ? '✅' : '❌'}, ${entry.autoprice ? '✅' : '❌'}${
-                    isPremium ? `, ${entry.promoted === 1 ? '✅' : '❌'}, ` : ', '
-                }${entry.group})`;
+                }, ${entry.intent}, ${entry.enabled ? '✅' : '❌'}, ${entry.autoprice ? '✅' : '❌'}, ${entry.group}, ${
+                    entry.isPartialPriced ? '✅' : '❌'
+                }${isPremium ? `, ${entry.promoted === 1 ? '✅' : '❌'}` : ''})`;
             });
             const listCount = list.length;
 
@@ -1449,8 +1477,8 @@ export default class PricelistManagerCommands {
                                   ? ` (limit set to ${limit})`
                                   : ''
                           }.`
-                }\n\n 📌 #. "sku" - "name" ("Current Stock", "min", "max", "intent", "enabled", "autoprice", *"promoted", "group")\n\n` +
-                    '* - Only shown if your account is Backpack.tf Premium\n\n.'
+                }\n\n 📌 #. "sku" - "name" ("Current Stock", "min", "max", "intent", "enabled", "autoprice", "group", "isPartialPriced", *"promoted",)\n\n` +
+                    '* - Only shown if your account is Backpack.tf Premium.\n\n.'
             );
 
             const applyLimit = limit === -1 ? listCount : limit;

--- a/src/classes/MyHandler/offer/accepted/updateListings.ts
+++ b/src/classes/MyHandler/offer/accepted/updateListings.ts
@@ -119,7 +119,7 @@ export default function updateListings(
         const isUpdatePartialPricedItem =
             inPrice !== null &&
             inPrice.autoprice &&
-            inPrice.group === 'isPartialPriced' &&
+            inPrice.isPartialPriced &&
             bot.inventoryManager.getInventory.getAmount(sku, true) < 1 && // current stock
             isNotPureOrWeapons;
 
@@ -337,7 +337,7 @@ export default function updateListings(
                     }
                 });
         } else if (isUpdatePartialPricedItem) {
-            // If item exist in pricelist with group "isPartialPriced" and we no longer have that in stock,
+            // If item exist in pricelist with "isPartialPriced" set to true and we no longer have that in stock,
             // then update entry with the latest prices.
 
             const oldPrice = {
@@ -352,7 +352,7 @@ export default function updateListings(
                 min: inPrice.min,
                 max: inPrice.max,
                 intent: inPrice.intent,
-                group: 'all'
+                group: inPrice.group
             } as EntryData;
 
             bot.pricelist

--- a/src/schemas/pricelist-json/pricelist-add.ts
+++ b/src/schemas/pricelist-json/pricelist-add.ts
@@ -22,16 +22,16 @@ export const addSchema: jsonschema.Schema = {
             // if the item is autopriced or not
             type: 'boolean'
         },
+        min: {
+            // minimum stock
+            type: 'integer',
+            minimum: 0
+        },
         max: {
             // maximum stock
             type: 'integer',
             // -1 is infinite
             minimum: -1
-        },
-        min: {
-            // minimum stock
-            type: 'integer',
-            minimum: 0
         },
         buy: {
             // buy price
@@ -59,6 +59,10 @@ export const addSchema: jsonschema.Schema = {
         },
         note: {
             $ref: 'listing-note'
+        },
+        isPartialPriced: {
+            // partialPrice feature: https://github.com/TF2Autobot/tf2autobot/pull/520
+            type: 'boolean'
         }
     },
     additionalProperties: false,

--- a/src/schemas/pricelist-json/pricelist.ts
+++ b/src/schemas/pricelist-json/pricelist.ts
@@ -26,16 +26,16 @@ export const pricelistSchema: jsonschema.Schema = {
             // if the item is autopriced or not
             type: 'boolean'
         },
+        min: {
+            // minimum stock
+            type: 'integer',
+            minimum: 0
+        },
         max: {
             // maximum stock
             type: 'integer',
             // -1 is infinite
             minimum: -1
-        },
-        min: {
-            // minimum stock
-            type: 'integer',
-            minimum: 0
         },
         buy: {
             // buy price
@@ -63,6 +63,10 @@ export const pricelistSchema: jsonschema.Schema = {
         },
         note: {
             $ref: 'listing-note'
+        },
+        isPartialPriced: {
+            // partialPrice feature: https://github.com/TF2Autobot/tf2autobot/pull/520
+            type: 'boolean'
         },
         time: {
             // time when the price changed


### PR DESCRIPTION
- any existing "isPartialPriced" group will be reset to "all" and `isPartialPriced` will be set to `true` (will be set to `false` if the group is not "isPartialPriced") when updating the bot to the latest version.