### PR TITLE
🦾 catch error like a boss

### DIFF
--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -652,7 +652,7 @@ export default class Pricelist extends EventEmitter {
                         log.debug('Done update old prices...');
                     })
                     .catch(err => {
-                        log.error('Error on updateOldPrices', err);
+                        log.error('Error on updateOldPrices:', err);
                     });
             })
             .catch(err => {
@@ -790,7 +790,7 @@ export default class Pricelist extends EventEmitter {
                         currPrice.enabled = false;
                         currPrice.group = 'failed-updateOldPrices';
                         this.failedUpdateOldPrices.push(sku);
-                        log.warn(`updateOldPrices failed for ${sku}`, err);
+                        log.error(`updateOldPrices failed for ${sku}`, err);
                         pricesChanged = true;
                     }
 

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -647,7 +647,13 @@ export default class Pricelist extends EventEmitter {
                     return;
                 }
 
-                return this.updateOldPrices(old);
+                return this.updateOldPrices(old)
+                    .then(() => {
+                        log.debug('Done update old prices...');
+                    })
+                    .catch(err => {
+                        log.error('Error on updateOldPrices', err);
+                    });
             })
             .catch(err => {
                 log.debug('❌ Unable to get key prices: ', err);


### PR DESCRIPTION
- ✅ catch error on `updateOldPrices` method so it will not get caught on `setupPricelist` method (which will result in using temporary key prices).

![image](https://user-images.githubusercontent.com/47635037/113498853-52d57380-9543-11eb-8790-fcca0a295b0c.png)
