### PR TITLE
✨ opt to show detailed time taken

### DIFF
--- a/src/classes/Carts/UserCart.ts
+++ b/src/classes/Carts/UserCart.ts
@@ -382,6 +382,8 @@ export default class UserCart extends Cart {
             return Promise.reject('cart is empty');
         }
 
+        const start = Date.now();
+
         const offer = this.bot.manager.createOffer(this.partner);
 
         const alteredMessages: string[] = [];
@@ -1043,6 +1045,10 @@ export default class UserCart extends Cart {
 
         // clear memory
         theirInventory.clearFetch();
+
+        const timeTaken = Date.now() - start;
+        offer.data('constructOfferTime', timeTaken);
+        log.debug(`Constructing offer took ${timeTaken} ms`);
 
         return alteredMessages.length === 0 ? undefined : alteredMessages.join(', ');
     }

--- a/src/classes/Handler.ts
+++ b/src/classes/Handler.ts
@@ -143,7 +143,7 @@ export default abstract class Handler {
      * @param offer - The offer that changed
      * @param oldState - The old state of the offer
      */
-    onTradeOfferChanged(offer: TradeOfferManager.TradeOffer, oldState: number, processTime?: number): void {
+    onTradeOfferChanged(offer: TradeOfferManager.TradeOffer, oldState: number, timeTakenToComplete?: number): void {
         // empty function
     }
 

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -1852,7 +1852,7 @@ export default class MyHandler extends Handler {
         };
     }
 
-    onTradeOfferChanged(offer: TradeOffer, oldState: number, processTime?: number): void {
+    onTradeOfferChanged(offer: TradeOffer, oldState: number, timeTakenToComplete?: number): void {
         // Not sure if it can go from other states to active
         if (oldState === TradeOfferManager.ETradeOfferState['Accepted']) {
             offer.data('switchedState', oldState);
@@ -1906,7 +1906,7 @@ export default class MyHandler extends Handler {
 
                 this.autokeys.check();
 
-                const result = processAccepted(offer, this.bot, this.isTradingKeys, processTime);
+                const result = processAccepted(offer, this.bot, this.isTradingKeys, timeTakenToComplete);
                 this.isTradingKeys = false; // reset
 
                 highValue.isDisableSKU = result.isDisableSKU;

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -117,6 +117,7 @@ export const DEFAULTS = {
     tradeSummary: {
         showStockChanges: false,
         showTimeTakenInMS: false,
+        showDetailedTimeTaken: true,
         showItemPrices: true,
         showPureInEmoji: false,
         showProperName: false,
@@ -1100,6 +1101,7 @@ interface OnlyAllow {
 interface TradeSummary {
     showStockChanges?: boolean;
     showTimeTakenInMS?: boolean;
+    showDetailedTimeTaken?: boolean;
     showItemPrices?: boolean;
     showPureInEmoji?: boolean;
     showProperName?: boolean;

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -279,7 +279,10 @@ export default class Trades {
             }
 
             offer.data('handledByUs', true);
-            offer.data('handleTime', dayjs().valueOf() - start);
+            const timeTaken = dayjs().valueOf() - start;
+
+            offer.data('processOfferTime', timeTaken);
+            log.debug(`Processing offer #${offer.id} took ${timeTaken} ms`);
 
             offer.log('debug', 'handler is done with offer', {
                 response: response
@@ -1029,7 +1032,7 @@ export default class Trades {
 
         const finishTimestamp = dayjs().valueOf();
 
-        const processTime = finishTimestamp - offer.data('handleTimestamp');
+        const timeTakenToComplete = finishTimestamp - offer.data('handleTimestamp');
 
         if (
             offer.state === TradeOfferManager.ETradeOfferState['Active'] ||
@@ -1060,10 +1063,10 @@ export default class Trades {
 
             offer.data('finishTimestamp', finishTimestamp);
 
-            log.debug(`Took ${isNaN(processTime) ? 'unknown' : processTime} ms to process offer`, {
+            log.debug(`Took ${isNaN(timeTakenToComplete) ? 'unknown' : timeTakenToComplete} ms to complete the offer`, {
                 offerId: offer.id,
                 state: offer.state,
-                finishTime: processTime
+                finishTime: timeTakenToComplete
             });
         }
 
@@ -1085,7 +1088,7 @@ export default class Trades {
         this.bot.client.gamesPlayed([]);
 
         void this.bot.inventoryManager.getInventory.fetch().asCallback(() => {
-            this.bot.handler.onTradeOfferChanged(offer, oldState, processTime);
+            this.bot.handler.onTradeOfferChanged(offer, oldState, timeTakenToComplete);
         });
     }
 

--- a/src/lib/DiscordWebhook/sendTradeSummary.ts
+++ b/src/lib/DiscordWebhook/sendTradeSummary.ts
@@ -11,7 +11,8 @@ export default async function sendTradeSummary(
     offer: TradeOffer,
     accepted: Accepted,
     bot: Bot,
-    processTime: number,
+    timeTakenToComplete: number,
+    timeTakenToProcessOrConstruct: number,
     isTradingKeys: boolean,
     isOfferSent: boolean | undefined
 ): Promise<void> {
@@ -104,7 +105,8 @@ export default async function sendTradeSummary(
     const autokeys = bot.handler.autokeys;
     const status = autokeys.getOverallStatus;
 
-    const cT = bot.options.tradeSummary.customText;
+    const tSum = optBot.tradeSummary;
+    const cT = tSum.customText;
     const cTTimeTaken = cT.timeTaken.discordWebhook ? cT.timeTaken.discordWebhook : '⏱ **Time taken:**';
     const cTKeyRate = cT.keyRate.discordWebhook ? cT.keyRate.discordWebhook : '🔑 Key rate:';
     const cTPureStock = cT.pureStock.discordWebhook ? cT.pureStock.discordWebhook : '💰 Pure stock:';
@@ -126,7 +128,13 @@ export default async function sendTradeSummary(
                 },
                 description:
                     summary +
-                    `\n${cTTimeTaken} ${t.convertTime(processTime, optBot.tradeSummary.showTimeTakenInMS)}\n\n` +
+                    `\n${cTTimeTaken} ${t.convertTime(
+                        timeTakenToComplete,
+                        timeTakenToProcessOrConstruct,
+                        isOfferSent,
+                        tSum.showDetailedTimeTaken,
+                        tSum.showTimeTakenInMS
+                    )}\n\n` +
                     (misc.showQuickLinks ? `${quickLinks(t.replace.specialChar(details.personaName), links)}\n` : '\n'),
                 fields: [
                     {

--- a/src/lib/tools/time.ts
+++ b/src/lib/tools/time.ts
@@ -95,11 +95,23 @@ export function timeNow(opt: Options): { timeUnix: number; time: string; emoji: 
     };
 }
 
-export function convertTime(time: number, showInMS: boolean): string {
+export function convertTime(
+    completeTime: number,
+    processOrConstructTime: number,
+    isOfferSent: boolean,
+    showDetailedTimeTaken: boolean,
+    showInMS: boolean
+): string {
     const now = dayjs();
-    const timeText = `${dayjs.unix(Math.round((now.valueOf() - time) / 1000)).fromNow(true)}${
-        showInMS ? ` (${time} ms)` : ''
-    }`;
+    const timeText = showDetailedTimeTaken
+        ? `\n- ${isOfferSent ? 'To construct offer' : 'To process offer'}: ${dayjs
+              .unix(Math.round((now.valueOf() - processOrConstructTime) / 1000))
+              .fromNow(true)}${showInMS ? ` (${processOrConstructTime} ms)` : ''}\n- To complete: ${dayjs
+              .unix(Math.round((now.valueOf() - completeTime) / 1000))
+              .fromNow(true)}${showInMS ? ` (${completeTime} ms)` : ''}`
+        : `${dayjs.unix(Math.round((now.valueOf() - completeTime) / 1000)).fromNow(true)}${
+              showInMS ? ` (${completeTime} ms)` : ''
+          }`;
     return timeText;
 }
 

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -490,6 +490,7 @@ export const optionsSchema: jsonschema.Schema = {
                         'onUpdate',
                         'onSuccessUpdatePartialPriced',
                         'onFailedUpdatePartialPriced',
+                        'onBulkUpdatePartialPriced',
                         'onResetAfterThreshold'
                     ],
                     additionalProperties: false
@@ -601,6 +602,9 @@ export const optionsSchema: jsonschema.Schema = {
                 showTimeTakenInMS: {
                     type: 'boolean'
                 },
+                showDetailedTimeTaken: {
+                    type: 'boolean'
+                },
                 showItemPrices: {
                     type: 'boolean'
                 },
@@ -675,7 +679,14 @@ export const optionsSchema: jsonschema.Schema = {
                     additionalProperties: false
                 }
             },
-            required: ['showStockChanges', 'showTimeTakenInMS', 'showItemPrices', 'showPureInEmoji', 'customText'],
+            required: [
+                'showStockChanges',
+                'showTimeTakenInMS',
+                'showDetailedTimeTaken',
+                'showItemPrices',
+                'showPureInEmoji',
+                'customText'
+            ],
             additionalProperties: false
         },
 

--- a/src/types/modules/@tf2autobot/tradeoffer-manager/index.d.ts
+++ b/src/types/modules/@tf2autobot/tradeoffer-manager/index.d.ts
@@ -96,7 +96,8 @@ declare module '@tf2autobot/tradeoffer-manager' {
             value?: ItemsValue;
             prices?: Prices;
             handledByUs?: boolean;
-            handleTime?: number;
+            processOfferTime?: number;
+            constructOfferTime?: number;
             actionTimestamp?: number;
             confirmationTime?: number;
             finishTimestamp?: number;


### PR DESCRIPTION
- Show time taken to construct offer (if trade partner use chat) or to process offer (if trade partner sent an offer to the bot) in the trade summary "Time taken".
- New option: `tradeSummary.showDetailedTimeTaken` (default is `true`).