### PR TITLE
✨ detect item with Legacy Paint

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -550,7 +550,7 @@ export default class Bot {
     private setProperties(): void {
         this.effects = this.schema.getUnusualEffects();
         this.paints = this.schema.getPaints();
-        this.paints['Legacy Paint'] = 'p5801378'; // use red attribute
+        this.paints['Legacy Paint'] = 'p5801378'; // use blue attribute
         this.strangeParts = this.schema.getStrangeParts();
         this.craftWeapons = this.schema.getCraftableWeaponsForTrading();
         this.uncraftWeapons = this.schema.getUncraftableWeaponsForTrading();

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -550,6 +550,7 @@ export default class Bot {
     private setProperties(): void {
         this.effects = this.schema.getUnusualEffects();
         this.paints = this.schema.getPaints();
+        this.paints['Legacy Paint'] = 'p5801378'; // use red attribute
         this.strangeParts = this.schema.getStrangeParts();
         this.craftWeapons = this.schema.getCraftableWeaponsForTrading();
         this.uncraftWeapons = this.schema.getUncraftableWeaponsForTrading();

--- a/src/classes/Inventory.ts
+++ b/src/classes/Inventory.ts
@@ -390,6 +390,10 @@ function highValue(
         }
     }
 
+    if (econ.icon_url.includes('SLcfMQEs5nqWSMU5OD2NwHzHZdmi') && Object.keys(p).length === 0) {
+        p['p5801378'] = true; // Legacy Paint
+    }
+
     [s, sp, ke, ks, p].forEach((attachment, i) => {
         if (Object.keys(attachment).length > 0) {
             attributes[['s', 'sp', 'ke', 'ks', 'p'][i]] = attachment;

--- a/src/classes/MyHandler/offer/accepted/updateListings.ts
+++ b/src/classes/MyHandler/offer/accepted/updateListings.ts
@@ -96,23 +96,7 @@ export default function updateListings(
             !isAdmin;
 
         const isAutoDisableHighValueItems =
-            existInPricelist &&
-            isDisabledHV &&
-            (normalizePainted.our === false
-                ? !highValue.theirItems.some(
-                      str =>
-                          str.includes(name) &&
-                          str.includes('🎨 Painted') &&
-                          !(
-                              str.includes('🎰 Parts') ||
-                              str.includes('🔥 Killstreaker') ||
-                              str.includes('✨ Sheen') ||
-                              str.includes('🎃 Spells')
-                          )
-                  )
-                : true) &&
-            isNotPureOrWeapons &&
-            opt.highValue.enableHold;
+            existInPricelist && isDisabledHV && isNotPureOrWeapons && opt.highValue.enableHold;
 
         const isAutoRemoveIntentSell =
             opt.pricelist.autoRemoveIntentSell.enable &&
@@ -137,7 +121,9 @@ export default function updateListings(
 
             const priceFromOptions =
                 opt.detailsExtra.painted[
-                    bot.schema.getPaintNameByDecimal(parseInt(pSKU.replace('p', ''), 10)) as PaintedNames
+                    pSKU === 'p5801378'
+                        ? 'Legacy Paint'
+                        : (bot.schema.getPaintNameByDecimal(parseInt(pSKU.replace('p', ''), 10)) as PaintedNames)
                 ].price;
 
             const keyPriceInRef = bot.pricelist.getKeyPrice.metal;
@@ -178,7 +164,11 @@ export default function updateListings(
                 .addPrice(entry, true)
                 .then(data => {
                     const msg =
-                        `✅ Automatically added ${bot.schema.getName(SKU.fromString(paintedSKU), false)}` +
+                        `✅ Automatically added ${
+                            pSKU === 'p5801378'
+                                ? `${bot.schema.getName(SKU.fromString(sku), false)} (Legacy Paint)`
+                                : bot.schema.getName(SKU.fromString(paintedSKU), false)
+                        }` +
                         ` (${paintedSKU}) to sell.` +
                         `\nBase price: ${inPrice.buy.toString()}/${inPrice.sell.toString()}` +
                         `\nSelling for: ${data.sell.toString()} ` +

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -919,6 +919,13 @@ export const DEFAULTS = {
                     keys: 0,
                     metal: 30
                 }
+            },
+            'Legacy Paint': {
+                stringNote: '🔵⛔',
+                price: {
+                    keys: 4,
+                    metal: 0
+                }
             }
         },
         /**
@@ -1693,6 +1700,7 @@ interface Painted {
     'Team Spirit'?: PaintedProperties;
     'The Value of Teamwork'?: PaintedProperties;
     'Waterlogged Lab Coat'?: PaintedProperties;
+    'Legacy Paint'?: PaintedProperties;
 }
 
 export type PaintedNames =
@@ -1724,7 +1732,8 @@ export type PaintedNames =
     | 'Cream Spirit'
     | 'Team Spirit'
     | 'The Value of Teamwork'
-    | 'Waterlogged Lab Coat';
+    | 'Waterlogged Lab Coat'
+    | 'Legacy Paint';
 
 interface StrangeParts {
     'Robots Destroyed'?: string;

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -1990,6 +1990,9 @@ export const optionsSchema: jsonschema.Schema = {
                         },
                         'Waterlogged Lab Coat': {
                             $ref: '#/definitions/painted-properties'
+                        },
+                        'Legacy Paint': {
+                            $ref: '#/definitions/painted-properties'
                         }
                     },
                     required: [
@@ -2021,7 +2024,8 @@ export const optionsSchema: jsonschema.Schema = {
                         'Cream Spirit',
                         'Team Spirit',
                         'The Value of Teamwork',
-                        'Waterlogged Lab Coat'
+                        'Waterlogged Lab Coat',
+                        'Legacy Paint'
                     ],
                     additionalProperties: false
                 },


### PR DESCRIPTION
Legacy Painted item does not have a description on them, thus we use image URL to detect if the item is Team Spirit painted. Legacy Paint is Team Spirit will missing blue color attribute.

![image](https://user-images.githubusercontent.com/47635037/115179360-bfd13780-a105-11eb-98ca-e172076fb81d.png)


Example of an item with Legacy Paint:
![image](https://user-images.githubusercontent.com/47635037/115189057-72aa9100-a118-11eb-960c-177ec3d10700.png)
![image](https://user-images.githubusercontent.com/47635037/115189107-8950e800-a118-11eb-95c2-bf40fa850f87.png)

Regular Team Spirit:
![image](https://user-images.githubusercontent.com/47635037/115189159-a2599900-a118-11eb-92f9-9164ea9bfd93.png)
![image](https://user-images.githubusercontent.com/47635037/115189224-bd2c0d80-a118-11eb-8ce9-b79b51bd347c.png)

