### PR TITLE
✨ support processing Non-TF2 items (offer only)

### DIFF
--- a/src/classes/Commands/sub-classes/Review.ts
+++ b/src/classes/Commands/sub-classes/Review.ts
@@ -7,7 +7,7 @@ import SKU from 'tf2-sku-2';
 import SchemaManager from 'tf2-schema-2';
 import Bot from '../../Bot';
 import CommandParser from '../../CommandParser';
-import { generateLinks } from '../../../lib/tools/export';
+import { generateLinks, testSKU } from '../../../lib/tools/export';
 
 // Manual review commands
 
@@ -146,7 +146,9 @@ export default class ReviewCommands {
                     continue;
                 }
 
-                summary.push(schema.getName(SKU.fromString(sku), false) + (dict[sku] > 1 ? ` x${dict[sku]}` : '')); // dict[sku] = amount
+                const name = testSKU(sku) ? schema.getName(SKU.fromString(sku), false) : sku;
+
+                summary.push(name + (dict[sku] > 1 ? ` x${dict[sku]}` : '')); // dict[sku] = amount
             }
 
             if (summary.length === 0) {

--- a/src/classes/MyHandler/offer/accepted/processAccepted.ts
+++ b/src/classes/MyHandler/offer/accepted/processAccepted.ts
@@ -41,13 +41,9 @@ export default function processAccepted(
                 // doing this so it will only executed if includes 🟨_INVALID_ITEMS reason.
 
                 (meta.reasons.filter(el => el.reason === '🟨_INVALID_ITEMS') as i.InvalidItems[]).forEach(el => {
-                    accepted.invalidItems.push(
-                        `${
-                            isWebhookEnabled
-                                ? `_${bot.schema.getName(SKU.fromString(el.sku), false)}_`
-                                : bot.schema.getName(SKU.fromString(el.sku), false)
-                        } - ${el.price}`
-                    );
+                    const name = t.testSKU(el.sku) ? bot.schema.getName(SKU.fromString(el.sku), false) : el.sku;
+
+                    accepted.invalidItems.push(`${isWebhookEnabled ? `_${name}_` : name} - ${el.price}`);
                 });
             }
             if (meta?.uniqueReasons?.includes('🟧_DISABLED_ITEMS')) {

--- a/src/classes/MyHandler/offer/accepted/updateListings.ts
+++ b/src/classes/MyHandler/offer/accepted/updateListings.ts
@@ -10,6 +10,7 @@ import { EntryData } from '../../../Pricelist';
 import log from '../../../../lib/logger';
 import { sendAlert } from '../../../../lib/DiscordWebhook/export';
 import { PaintedNames } from '../../../Options';
+import { testSKU } from '../../../../lib/tools/export';
 
 let itemsFromPreviousTrades: string[] = [];
 
@@ -40,6 +41,10 @@ export default function updateListings(
 
     for (const sku in diff) {
         if (!Object.prototype.hasOwnProperty.call(diff, sku)) {
+            continue;
+        }
+
+        if (!testSKU(sku)) {
             continue;
         }
 

--- a/src/classes/MyHandler/offer/review/reasons/invalidItems.ts
+++ b/src/classes/MyHandler/offer/review/reasons/invalidItems.ts
@@ -2,6 +2,7 @@ import SKU from 'tf2-sku-2';
 import pluralize from 'pluralize';
 import { Meta, InvalidItems } from '@tf2autobot/tradeoffer-manager';
 import Bot from '../../../../Bot';
+import { testSKU } from '../../../../../lib/tools/export';
 
 export default function invalidItems(meta: Meta, bot: Bot): { note: string; name: string[] } {
     const opt = bot.options.discordWebhook.offerReview;
@@ -9,7 +10,7 @@ export default function invalidItems(meta: Meta, bot: Bot): { note: string; name
     const invalidForOur: string[] = []; // Display for owner
 
     (meta.reasons.filter(el => el.reason.includes('🟨_INVALID_ITEMS')) as InvalidItems[]).forEach(el => {
-        const name = bot.schema.getName(SKU.fromString(el.sku), false);
+        const name = testSKU(el.sku) ? bot.schema.getName(SKU.fromString(el.sku), false) : el.sku;
 
         if (opt.enable && opt.url !== '') {
             // show both item name and prices.tf price

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -273,6 +273,7 @@ export const DEFAULTS = {
         sendPreAcceptMessage: {
             enable: true
         },
+        alwaysDeclineNonTF2Items: true,
         // 🟥_INVALID_VALUE
         invalidValue: {
             autoDecline: {
@@ -1269,6 +1270,7 @@ interface Metals extends OnlyEnable {
 
 interface OfferReceived {
     sendPreAcceptMessage?: OnlyEnable;
+    alwaysDeclineNonTF2Items?: boolean;
     invalidValue?: InvalidValue;
     invalidItems?: InvalidItems;
     disabledItems?: AutoAcceptOverpayAndAutoDecline;

--- a/src/lib/extend/item/getSKU.ts
+++ b/src/lib/extend/item/getSKU.ts
@@ -18,6 +18,10 @@ export = function (
     const self = this as EconItem;
 
     if (self.appid != 440) {
+        if (self.type && self.market_name) {
+            return `${self.type}: ${self.market_name}`;
+        }
+
         return 'unknown';
     }
 

--- a/src/lib/tools/export.ts
+++ b/src/lib/tools/export.ts
@@ -9,6 +9,7 @@ import listItems from './summarizeItems';
 import summarize, { summarizeToChat } from './summarizeOffer';
 import profit from './profit';
 import itemStats from './itemStats';
+import testSKU from './testSKU';
 
 export {
     getHighValueItems,
@@ -26,5 +27,6 @@ export {
     uptime,
     convertTime,
     profit,
-    itemStats
+    itemStats,
+    testSKU
 };

--- a/src/lib/tools/getHighValue.ts
+++ b/src/lib/tools/getHighValue.ts
@@ -3,6 +3,7 @@ import { Items } from '@tf2autobot/tradeoffer-manager';
 import { spellsData, killstreakersData, sheensData } from '../data';
 import Bot from '../../classes/Bot';
 import { Paints, StrangeParts } from 'tf2-schema-2';
+import { testSKU } from '../tools/export';
 
 export default function getHighValueItems(
     items: Items,
@@ -19,6 +20,10 @@ export default function getHighValueItems(
 
     for (const sku in items) {
         if (!Object.prototype.hasOwnProperty.call(items, sku)) {
+            continue;
+        }
+
+        if (!testSKU(sku)) {
             continue;
         }
 

--- a/src/lib/tools/summarizeItems.ts
+++ b/src/lib/tools/summarizeItems.ts
@@ -2,7 +2,7 @@ import { TradeOffer, Prices } from '@tf2autobot/tradeoffer-manager';
 import SKU from 'tf2-sku-2';
 import Currencies from 'tf2-currencies-2';
 import Bot from '../../classes/Bot';
-import { replace } from '../tools/export';
+import { replace, testSKU } from '../tools/export';
 
 export default function listItems(
     offer: TradeOffer,
@@ -134,7 +134,7 @@ function listPrices(offer: TradeOffer, bot: Bot, isSteamChat: boolean): string {
             sellPrice = new Currencies(prices[sku].sell).toString();
         }
 
-        const name = bot.schema.getName(SKU.fromString(sku), properName);
+        const name = testSKU(sku) ? bot.schema.getName(SKU.fromString(sku), properName) : sku;
 
         toJoin.push(
             `${

--- a/src/lib/tools/summarizeOffer.ts
+++ b/src/lib/tools/summarizeOffer.ts
@@ -89,8 +89,6 @@ export function summarizeToChat(
 type SummarizeType = 'summary-accepted' | 'declined' | 'review-partner' | 'review-admin' | 'summary-accepting';
 
 import Currencies from 'tf2-currencies-2';
-import SKU from 'tf2-sku-2';
-import { replace } from '../tools/export';
 
 export default function summarize(
     offer: TradeOffer,
@@ -144,6 +142,9 @@ export default function summarize(
     }
 }
 
+import SKU from 'tf2-sku-2';
+import { replace, testSKU } from '../tools/export';
+
 function getSummary(
     dict: OurTheirItemsDict,
     bot: Bot,
@@ -165,9 +166,13 @@ function getSummary(
             continue;
         }
 
+        const isTF2Items = testSKU(sku);
+
         // compatible with pollData from before v3.0.0 / before v2.2.0 and/or v3.0.0 or later ↓
         const amount = typeof dict[sku] === 'object' ? (dict[sku]['amount'] as number) : dict[sku];
-        const generateName = bot.schema.getName(SKU.fromString(sku.replace(/;p\d+/, '')), properName);
+        const generateName = isTF2Items
+            ? bot.schema.getName(SKU.fromString(sku.replace(/;p\d+/, '')), properName)
+            : sku; // Non-TF2 items
         const name = properName ? generateName : replace.itemName(generateName ? generateName : 'unknown');
 
         if (showStockChanges) {
@@ -191,7 +196,7 @@ function getSummary(
                 oldStock = currentStock;
             }
 
-            if (withLink) {
+            if (withLink && isTF2Items) {
                 summary.push(
                     `[${
                         bot.options.tradeSummary.showPureInEmoji
@@ -229,7 +234,7 @@ function getSummary(
                 );
             }
         } else {
-            if (withLink) {
+            if (withLink && isTF2Items) {
                 summary.push(
                     `[${
                         bot.options.tradeSummary.showPureInEmoji

--- a/src/lib/tools/testSKU.ts
+++ b/src/lib/tools/testSKU.ts
@@ -1,0 +1,5 @@
+export default function testSKU(sku: string): boolean {
+    return /^(\d+);([0-9]|[1][0-5])(;((uncraftable)|(untrad(e)?able)|(australium)|(festive)|(strange)|((u|pk|td-|c|od-|oq-|p)\d+)|(w[1-5])|(kt-[1-3])|(n((100)|[1-9]\d?))))*?$/.test(
+        sku
+    );
+}

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -992,6 +992,9 @@ export const optionsSchema: jsonschema.Schema = {
                 sendPreAcceptMessage: {
                     $ref: '#/definitions/only-enable'
                 },
+                alwaysDeclineNonTF2Items: {
+                    type: 'boolean'
+                },
                 invalidValue: {
                     type: 'object',
                     properties: {


### PR DESCRIPTION
- Trading Card, CS:GO items, etc (Discord Webhook: hyperlink not enabled).
- Cannot add to the pricelist.
- All offers that contain non-TF2 items will always be held for review under 🟨_INVALID_ITEMS (manually accept/decline it).
- Might cause -ve profit (on `!stats` or `!statsdw` commands) when accepted.
- New options.json property:
    - `offerReceived.alwaysDeclineNonTF2Items` (default is `true`)
- Steam Chat:
![image](https://user-images.githubusercontent.com/47635037/115261903-9d233b00-a166-11eb-8565-a68051ebf270.png)
![image](https://user-images.githubusercontent.com/47635037/115261946-a7ddd000-a166-11eb-997b-5b31ddb3940a.png)

- Discord Webhook:
![image](https://user-images.githubusercontent.com/47635037/115262002-b5935580-a166-11eb-96e9-88e6d9cf5924.png)
![image](https://user-images.githubusercontent.com/47635037/115262035-bd52fa00-a166-11eb-92f9-4ea941612ecf.png)


-- with `showStockChanges` enabled:
![image](https://user-images.githubusercontent.com/47635037/115263676-3272ff00-a168-11eb-9f8e-eb59c8a3676b.png)
![image](https://user-images.githubusercontent.com/47635037/115263707-39017680-a168-11eb-9884-97e1567dfd4c.png)

