### PR TITLE
✨ opt for amount to include non-normalized items

### DIFF
--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -359,7 +359,7 @@ export default class Commands {
             }
         }
 
-        reply += `.\n📦 I have ${this.bot.inventoryManager.getInventory.getAmount(match.sku, true)}`;
+        reply += `.\n📦 I have ${this.bot.inventoryManager.getInventory.getAmount(match.sku, false, true)}`;
 
         if (match.max !== -1 && isBuying) {
             reply += ` / ${match.max}`;
@@ -452,7 +452,7 @@ export default class Commands {
             );
 
         const cartAmount = cart.getOurCount(info.match.sku);
-        const ourAmount = this.bot.inventoryManager.getInventory.getAmount(info.match.sku, true);
+        const ourAmount = this.bot.inventoryManager.getInventory.getAmount(info.match.sku, false, true);
         const amountCanTrade = this.bot.inventoryManager.amountCanTrade(info.match.sku, false) - cartAmount;
 
         const name = this.bot.schema.getName(SKU.fromString(info.match.sku), false);
@@ -912,7 +912,7 @@ export default class Commands {
                 this.weaponsAsCurrency.enable && this.weaponsAsCurrency.withUncraft ? this.bot.uncraftWeapons : []
             );
         const cartAmount = cart.getOurCount(params.sku);
-        const ourAmount = this.bot.inventoryManager.getInventory.getAmount(params.sku, true);
+        const ourAmount = this.bot.inventoryManager.getInventory.getAmount(params.sku, false, true);
         const amountCanTrade = ourAmount - cartAmount;
         const name = this.bot.schema.getName(SKU.fromString(params.sku), false);
 
@@ -1004,7 +1004,7 @@ export default class Commands {
             );
 
         const cartAmount = cart.getOurCount(params.sku);
-        const ourAmount = this.bot.inventoryManager.getInventory.getAmount(params.sku, true);
+        const ourAmount = this.bot.inventoryManager.getInventory.getAmount(params.sku, false, true);
         const amountCanTrade = ourAmount - cart.getOurCount(params.sku) - cartAmount;
 
         const name = this.bot.schema.getName(SKU.fromString(params.sku), false);
@@ -1114,7 +1114,7 @@ export default class Commands {
         const numEvens = numMonths - numOdds;
         const amountKeys = Math.round(numOdds * 3 + numEvens * 2);
 
-        const ourAmount = this.bot.inventoryManager.getInventory.getAmount('5021;6', true);
+        const ourAmount = this.bot.inventoryManager.getInventory.getAmount('5021;6', false, true);
 
         if (ourAmount < amountKeys) {
             return this.bot.sendMessage(

--- a/src/classes/Commands/sub-classes/Misc.ts
+++ b/src/classes/Commands/sub-classes/Misc.ts
@@ -139,19 +139,19 @@ export default class MiscCommands {
             const pure = [
                 {
                     name: 'Mann Co. Supply Crate Key',
-                    amount: inventory.getAmount('5021;6')
+                    amount: inventory.getAmount('5021;6', false)
                 },
                 {
                     name: 'Refined Metal',
-                    amount: inventory.getAmount('5002;6')
+                    amount: inventory.getAmount('5002;6', false)
                 },
                 {
                     name: 'Reclaimed Metal',
-                    amount: inventory.getAmount('5001;6')
+                    amount: inventory.getAmount('5001;6', false)
                 },
                 {
                     name: 'Scrap Metal',
-                    amount: inventory.getAmount('5000;6')
+                    amount: inventory.getAmount('5000;6', false)
                 }
             ];
 
@@ -227,7 +227,7 @@ export default class MiscCommands {
         const items: { amount: number; name: string }[] = [];
 
         type.forEach(sku => {
-            const amount = bot.inventoryManager.getInventory.getAmount(sku);
+            const amount = bot.inventoryManager.getInventory.getAmount(sku, false);
             if (amount > 0) {
                 items.push({
                     name: bot.schema.getName(SKU.fromString(sku), false),

--- a/src/classes/Commands/sub-classes/PricelistManager.ts
+++ b/src/classes/Commands/sub-classes/PricelistManager.ts
@@ -191,7 +191,7 @@ export default class PricelistManagerCommands {
     }
 
     private generateAddedReply(isPremium: boolean, entry: Entry): string {
-        const amount = this.bot.inventoryManager.getInventory.getAmount(entry.sku);
+        const amount = this.bot.inventoryManager.getInventory.getAmount(entry.sku, false);
         const reply =
             `\n💲 Buy: ${entry.buy.toString()} | Sell: ${entry.sell.toString()}` +
             `\n🛒 Intent: ${entry.intent === 2 ? 'bank' : entry.intent === 1 ? 'sell' : 'buy'}` +
@@ -951,7 +951,7 @@ export default class PricelistManagerCommands {
 
     private generateUpdateReply(isPremium: boolean, oldEntry: Entry, newEntry: Entry): string {
         const keyPrice = this.bot.pricelist.getKeyPrice;
-        const amount = this.bot.inventoryManager.getInventory.getAmount(oldEntry.sku);
+        const amount = this.bot.inventoryManager.getInventory.getAmount(oldEntry.sku, false);
 
         const reply =
             `\n💲 Buy: ${
@@ -1260,7 +1260,7 @@ export default class PricelistManagerCommands {
     }
 
     private generateOutput(filtered: Entry): string {
-        const currentStock = this.bot.inventoryManager.getInventory.getAmount(filtered.sku, true);
+        const currentStock = this.bot.inventoryManager.getInventory.getAmount(filtered.sku, false, true);
         filtered['stock'] = currentStock;
 
         return JSON.stringify(filtered, null, 4);
@@ -1278,7 +1278,7 @@ export default class PricelistManagerCommands {
 
         const list = pricelist.map((entry, i) => {
             const name = this.bot.schema.getName(SKU.fromString(entry.sku));
-            const stock = this.bot.inventoryManager.getInventory.getAmount(entry.sku, true);
+            const stock = this.bot.inventoryManager.getInventory.getAmount(entry.sku, false, true);
 
             return `${i + 1}. ${entry.sku} - ${name}${name.length > 40 ? '\n' : ' '}(${stock}, ${entry.min}, ${
                 entry.max
@@ -1454,7 +1454,7 @@ export default class PricelistManagerCommands {
 
             const list = filter.map((entry, i) => {
                 const name = this.bot.schema.getName(SKU.fromString(entry.sku));
-                const stock = this.bot.inventoryManager.getInventory.getAmount(entry.sku, true);
+                const stock = this.bot.inventoryManager.getInventory.getAmount(entry.sku, false, true);
 
                 return `${i + 1}. ${entry.sku} - ${name}${name.length > 40 ? '\n' : ' '}(${stock}, ${entry.min}, ${
                     entry.max

--- a/src/classes/Inventory.ts
+++ b/src/classes/Inventory.ts
@@ -183,7 +183,7 @@ export default class Inventory {
     }
 
     getAmount(sku: string, includeNonNormalized: boolean, tradableOnly?: boolean): number {
-        if (includeNonNormalized) {
+        if (includeNonNormalized && !['5021;6', '5002;6', '5001;6', '5000;6'].includes(sku)) {
             // This is true only on src/lib/tools/summarizeOffer.ts @ L180, and src/classes/InventoryManager.ts @ L69
             let accAmount = this.findBySKU(sku, tradableOnly).length;
 
@@ -192,56 +192,47 @@ export default class Inventory {
             const normPainted = optNormalize.painted;
             const normStrange = optNormalize.strangeAsSecondQuality;
 
-            const isIncludeNonNormalized =
-                normFestivized.amountIncludeNonFestivized ||
-                normPainted.amountIncludeNonPainted ||
-                normStrange.amountIncludeNonStrange;
+            const schemaItem = this.schema.getItemBySKU(sku);
+            if (schemaItem) {
+                const canBeFestivized =
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                    this.schema.raw.items_game.items[`${schemaItem.defindex}`].tags?.can_be_festivized == 1;
 
-            if (isIncludeNonNormalized && !['5021;6', '5002;6', '5001;6', '5000;6'].includes(sku)) {
-                // First just the amount of non-normalized
+                // Festivized
+                if (
+                    !sku.includes(';festive') &&
+                    canBeFestivized &&
+                    normFestivized.amountIncludeNonFestivized &&
+                    !normFestivized.our
+                ) {
+                    const item = SKU.fromString(sku);
+                    item.festive = true;
+                    accAmount += this.findBySKU(SKU.fromObject(item), tradableOnly).length;
+                }
 
-                const schemaItem = this.schema.getItemBySKU(sku);
-                if (schemaItem) {
-                    const canBeFestivized =
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                        this.schema.raw.items_game.items[`${schemaItem.defindex}`].tags?.can_be_festivized == 1;
-
-                    // Festivized
-                    if (
-                        !sku.includes(';festive') &&
-                        canBeFestivized &&
-                        !normFestivized.our &&
-                        normFestivized.amountIncludeNonFestivized
-                    ) {
-                        const item = SKU.fromString(sku);
-                        item.festive = true;
-                        accAmount += this.findBySKU(SKU.fromObject(item), tradableOnly).length;
+                // Painted
+                if (
+                    !/;[p][0-9]+/.test(sku) &&
+                    schemaItem.capabilities?.paintable &&
+                    normPainted.amountIncludeNonPainted &&
+                    !normPainted.our
+                ) {
+                    const paintPartialSKU = Object.values(this.paints);
+                    for (const pSKU of paintPartialSKU) {
+                        accAmount += this.findBySKU(`${sku};${pSKU}`, tradableOnly).length;
                     }
+                }
 
-                    // Painted
-                    if (
-                        !/;[p][0-9]+/.test(sku) &&
-                        schemaItem.capabilities?.paintable &&
-                        !normPainted.our &&
-                        normPainted.amountIncludeNonPainted
-                    ) {
-                        const paintPartialSKU = Object.values(this.paints);
-                        for (const pSKU of paintPartialSKU) {
-                            accAmount += this.findBySKU(`${sku};${pSKU}`, tradableOnly).length;
-                        }
-                    }
-
-                    // Strange as second quality
-                    if (
-                        !sku.includes(';strange') &&
-                        schemaItem.capabilities?.can_strangify &&
-                        !normStrange.our &&
-                        normPainted.amountIncludeNonPainted
-                    ) {
-                        const item = SKU.fromString(sku);
-                        item.quality2 = 11;
-                        accAmount += this.findBySKU(SKU.fromObject(item), tradableOnly).length;
-                    }
+                // Strange as second quality
+                if (
+                    !sku.includes(';strange') &&
+                    schemaItem.capabilities?.can_strangify &&
+                    normPainted.amountIncludeNonPainted &&
+                    !normStrange.our
+                ) {
+                    const item = SKU.fromString(sku);
+                    item.quality2 = 11;
+                    accAmount += this.findBySKU(SKU.fromObject(item), tradableOnly).length;
                 }
             }
 

--- a/src/classes/Inventory.ts
+++ b/src/classes/Inventory.ts
@@ -183,6 +183,58 @@ export default class Inventory {
     }
 
     getAmount(sku: string, tradableOnly?: boolean): number {
+        // First determine if the sku have ";festive", ";p#", or ";strange" on it
+        const isIncludeFestivePaintStrange =
+            sku.includes(';festive') || /;[p][0-9]+/.test(sku) || sku.includes(';strange');
+
+        if (!isIncludeFestivePaintStrange && !['5021;6', '5002;6', '5001;6', '5000;6'].includes(sku)) {
+            // If the sku does not have any of it (non-normalized) and is not Mann Co. Supply Crate Key and pure metal
+            // check if user set normalize[festivized || painted || strangeAsSecondQuality].our to false
+            const isNotNormalizedOur =
+                this.options.normalize.festivized.our === false ||
+                this.options.normalize.painted.our === false ||
+                this.options.normalize.strangeAsSecondQuality.our === false;
+
+            if (isNotNormalizedOur) {
+                // If any of it set to false, we get the amount of an item to include the non-normalized variants
+
+                const schemaItem = this.schema.getItemBySKU(sku);
+
+                const canBeFestivized =
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                    this.schema.raw.items_game.items[`${schemaItem.defindex}`].tags?.can_be_festivized === '1';
+
+                // First just the amount of non-normalized
+                let accAmount = this.findBySKU(sku, tradableOnly).length;
+
+                // Festivized
+                if (canBeFestivized && !this.options.normalize.festivized.our) {
+                    const item = SKU.fromString(sku);
+                    item.festive = true;
+                    accAmount += this.findBySKU(SKU.fromObject(item), tradableOnly).length;
+                }
+
+                // Painted
+                if (schemaItem?.capabilities?.paintable && !this.options.normalize.painted.our) {
+                    const paintPartialSKU = Object.values(this.paints);
+                    for (const pSKU of paintPartialSKU) {
+                        accAmount += this.findBySKU(`${sku};${pSKU}`, tradableOnly).length;
+                    }
+                }
+
+                // Strange as second quality
+                if (schemaItem?.capabilities?.can_strangify && !this.options.normalize.strangeAsSecondQuality.our) {
+                    const item = SKU.fromString(sku);
+                    item.quality2 = 11;
+                    accAmount += this.findBySKU(SKU.fromObject(item), tradableOnly).length;
+                }
+
+                // return accumulated amount
+                return accAmount;
+            }
+        }
+
+        // else just return amount
         return this.findBySKU(sku, tradableOnly).length;
     }
 

--- a/src/classes/InventoryManager.ts
+++ b/src/classes/InventoryManager.ts
@@ -66,7 +66,7 @@ export default class InventoryManager {
         const amount =
             genericCheck && match && genericIndex !== -1
                 ? this.inventory.getAmountOfGenerics(SKU.fromObject(gSku), true)
-                : this.inventory.getAmount(sku, true);
+                : this.inventory.getAmount(sku, true, true);
 
         if (match === null) {
             // No price for item

--- a/src/classes/Listings.ts
+++ b/src/classes/Listings.ts
@@ -635,7 +635,7 @@ export default class Listings {
                 .replace(/%price%/g, entry[key].toString())
                 .replace(/%name%/g, entry.name)
                 .replace(/%max_stock%/g, entry.max === -1 ? '∞' : entry.max.toString())
-                .replace(/%current_stock%/g, inventory.getAmount(entry.sku, true).toString())
+                .replace(/%current_stock%/g, inventory.getAmount(entry.sku, false, true).toString())
                 .replace(/%amount_trade%/g, amountCanTrade.toString());
             return newDetail;
         };

--- a/src/classes/MyHandler/offer/accepted/updateListings.ts
+++ b/src/classes/MyHandler/offer/accepted/updateListings.ts
@@ -55,7 +55,7 @@ export default function updateListings(
         const isNotPureOrWeapons = !pure.concat(weapons).includes(sku);
         const inPrice = bot.pricelist.getPrice(sku, false);
         const existInPricelist = inPrice !== null;
-        const amount = inventory.getAmount(sku, true);
+        const amount = inventory.getAmount(sku, false, true);
 
         const isDisabledHV = highValue.isDisableSKU.includes(sku);
         const isAdmin = bot.isAdmin(offer.partner);
@@ -73,7 +73,7 @@ export default function updateListings(
             hv[sku]?.s === undefined && // make sure spelled is undefined
             inPrice !== null && // base items must already in pricelist
             bot.pricelist.getPrice(`${sku};${Object.keys(hv[sku].p)[0]}`, false) === null && // painted items must not in pricelist
-            inventory.getAmount(`${sku};${Object.keys(hv[sku].p)[0]}`, true) > 0 &&
+            inventory.getAmount(`${sku};${Object.keys(hv[sku].p)[0]}`, false, true) > 0 &&
             opt.pricelist.autoAddPaintedItems.enable; // autoAddPaintedItems must enabled
 
         const isAutoaddInvalidItems =

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -188,18 +188,20 @@ export const DEFAULTS = {
     },
 
     normalize: {
-        amountIncludeNonNormalizedVariant: false,
         festivized: {
             our: false,
-            their: false
+            their: false,
+            amountIncludeNonFestivized: false
         },
         strangeAsSecondQuality: {
             our: false,
-            their: false
+            their: false,
+            amountIncludeNonStrange: false
         },
         painted: {
             our: true,
-            their: true
+            their: true,
+            amountIncludeNonPainted: false
         }
     },
 
@@ -1171,15 +1173,26 @@ interface HighValue {
 // ------------ Normalize ------------
 
 interface Normalize {
-    amountIncludeNonNormalizedVariant?: boolean;
-    festivized?: NormalizeOurOrTheir;
-    strangeAsSecondQuality?: NormalizeOurOrTheir;
-    painted?: NormalizeOurOrTheir;
+    festivized?: NormalizeFestivized;
+    strangeAsSecondQuality?: NormalizeStrange;
+    painted?: NormalizePainted;
 }
 
 interface NormalizeOurOrTheir {
     our?: boolean;
     their?: boolean;
+}
+
+interface NormalizeFestivized extends NormalizeOurOrTheir {
+    amountIncludeNonFestivized?: boolean;
+}
+
+interface NormalizeStrange extends NormalizeOurOrTheir {
+    amountIncludeNonStrange?: boolean;
+}
+
+interface NormalizePainted extends NormalizeOurOrTheir {
+    amountIncludeNonPainted?: boolean;
 }
 
 // ------------ Details ------------

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -188,6 +188,7 @@ export const DEFAULTS = {
     },
 
     normalize: {
+        amountIncludeNonNormalizedVariant: false,
         festivized: {
             our: false,
             their: false
@@ -1170,6 +1171,7 @@ interface HighValue {
 // ------------ Normalize ------------
 
 interface Normalize {
+    amountIncludeNonNormalizedVariant?: boolean;
     festivized?: NormalizeOurOrTheir;
     strangeAsSecondQuality?: NormalizeOurOrTheir;
     painted?: NormalizeOurOrTheir;

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -805,7 +805,7 @@ export default class Pricelist extends EventEmitter {
                 }
 
                 const sku = currPrice.sku;
-                const isInStock = inventory.getAmount(sku, true) > 0;
+                const isInStock = inventory.getAmount(sku, false, true) > 0;
                 const maxIsOne = currPrice.max === 1;
                 const isNotExcluded = !excludedSKU.includes(sku);
 
@@ -1024,7 +1024,7 @@ export default class Pricelist extends EventEmitter {
             };
 
             let pricesChanged = false;
-            const currentStock = this.bot.inventoryManager.getInventory.getAmount(match.sku, true);
+            const currentStock = this.bot.inventoryManager.getInventory.getAmount(match.sku, false, true);
 
             const ppu = opt.pricelist.partialPriceUpdate;
             const isInStock = currentStock > 0;

--- a/src/lib/tools/summarizeOffer.ts
+++ b/src/lib/tools/summarizeOffer.ts
@@ -177,7 +177,7 @@ function getSummary(
 
         if (showStockChanges) {
             let oldStock: number | null = 0;
-            const currentStock = bot.inventoryManager.getInventory.getAmount(sku, true);
+            const currentStock = bot.inventoryManager.getInventory.getAmount(sku, true, true);
             const maxStock = bot.pricelist.getPrice(sku, false);
 
             const summaryAccepted = ['summary-accepted'].includes(type);

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -755,6 +755,9 @@ export const optionsSchema: jsonschema.Schema = {
         normalize: {
             type: 'object',
             properties: {
+                amountIncludeNonNormalizedVariant: {
+                    type: 'boolean'
+                },
                 festivized: {
                     $ref: '#/definitions/normalize-which'
                 },
@@ -765,7 +768,7 @@ export const optionsSchema: jsonschema.Schema = {
                     $ref: '#/definitions/normalize-which'
                 }
             },
-            required: ['festivized', 'strangeAsSecondQuality', 'painted'],
+            required: ['amountIncludeNonNormalizedVariant', 'festivized', 'strangeAsSecondQuality', 'painted'],
             additionalProperties: false
         },
         details: {

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -22,19 +22,6 @@ export const optionsSchema: jsonschema.Schema = {
             required: ['enable'],
             additionalProperties: false
         },
-        'normalize-which': {
-            type: 'object',
-            properties: {
-                our: {
-                    type: 'boolean'
-                },
-                their: {
-                    type: 'boolean'
-                }
-            },
-            required: ['our', 'their'],
-            additionalProperties: false
-        },
         'only-allow': {
             type: 'object',
             properties: {
@@ -755,17 +742,53 @@ export const optionsSchema: jsonschema.Schema = {
         normalize: {
             type: 'object',
             properties: {
-                amountIncludeNonNormalizedVariant: {
-                    type: 'boolean'
-                },
                 festivized: {
-                    $ref: '#/definitions/normalize-which'
+                    type: 'object',
+                    properties: {
+                        our: {
+                            type: 'boolean'
+                        },
+                        their: {
+                            type: 'boolean'
+                        },
+                        amountIncludeNonFestivized: {
+                            type: 'boolean'
+                        }
+                    },
+                    required: ['our', 'their', 'amountIncludeNonFestivized'],
+                    additionalProperties: false
                 },
                 strangeAsSecondQuality: {
-                    $ref: '#/definitions/normalize-which'
+                    type: 'object',
+                    properties: {
+                        our: {
+                            type: 'boolean'
+                        },
+                        their: {
+                            type: 'boolean'
+                        },
+                        amountIncludeNonStrange: {
+                            type: 'boolean'
+                        }
+                    },
+                    required: ['our', 'their', 'amountIncludeNonStrange'],
+                    additionalProperties: false
                 },
                 painted: {
-                    $ref: '#/definitions/normalize-which'
+                    type: 'object',
+                    properties: {
+                        our: {
+                            type: 'boolean'
+                        },
+                        their: {
+                            type: 'boolean'
+                        },
+                        amountIncludeNonPainted: {
+                            type: 'boolean'
+                        }
+                    },
+                    required: ['our', 'their', 'amountIncludeNonPainted'],
+                    additionalProperties: false
                 }
             },
             required: ['amountIncludeNonNormalizedVariant', 'festivized', 'strangeAsSecondQuality', 'painted'],

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -791,7 +791,7 @@ export const optionsSchema: jsonschema.Schema = {
                     additionalProperties: false
                 }
             },
-            required: ['amountIncludeNonNormalizedVariant', 'festivized', 'strangeAsSecondQuality', 'painted'],
+            required: ['festivized', 'strangeAsSecondQuality', 'painted'],
             additionalProperties: false
         },
         details: {


### PR DESCRIPTION
- Currently, if you set `normalize.festivized.our` to `false` and `normalize.festivized.their` to `true`:
    - Let say you have a buy order for "Australium Rocket Launcher".
    - When the bot receives an item, let say "Festivized Australium Rocket Launcher", it's first recognized as "Australium Rocket Launcher" (it's normalized since `normalize.festivized.their` is set to `true`).
    - Then once the item is in the bot inventory, it's now recognized as "Festivized Australium Rocket Launcher", and thus the `amountCanBuy` is still not 0 and the buy order is still up.
- This implementation will also take into account the Non-Normalized variants.

## Tested
### Painted item
- Before (or set to `false`)
![image](https://user-images.githubusercontent.com/47635037/116976088-3f105f00-acf3-11eb-8926-6f501e08819c.png)
- After (set to `true`, No buy order created)
![image](https://user-images.githubusercontent.com/47635037/116975686-98c45980-acf2-11eb-94fd-abca744e5e77.png)

<!-- ![image](https://user-images.githubusercontent.com/47635037/116974537-db853200-acf0-11eb-86a9-ff72825bf5a4.png) -->

### Festivized item
- Before (or set to `false`): https://gyazo.com/1a4951b96b50c77c2d9d27afef1e1414
- After (set to `true`, No buy order created): https://gyazo.com/701761c0a0bba6b97fd96f942ac444b4