### PR TITLE
🐛 fix Team Spirit paint detected as Legacy Paint

### DIFF
--- a/src/classes/Inventory.ts
+++ b/src/classes/Inventory.ts
@@ -447,7 +447,11 @@ function highValue(
         }
     }
 
-    if (econ.icon_url.includes('SLcfMQEs5nqWSMU5OD2NwHzHZdmi') && Object.keys(p).length === 0) {
+    if (
+        !econ.type.includes('Tool') && // Not a Paint Can
+        econ.icon_url.includes('SLcfMQEs5nqWSMU5OD2NwHzHZdmi') &&
+        Object.keys(p).length === 0
+    ) {
         p['p5801378'] = true; // Legacy Paint
     }
 


### PR DESCRIPTION
fixes:
![TS](https://user-images.githubusercontent.com/47635037/116994408-40e61c80-ad0b-11eb-96fa-eec0bb705b57.png)
