### PR TITLE
🔨 fix repetitive false missing listings

### DIFF
--- a/src/classes/Commands/sub-classes/Manager.ts
+++ b/src/classes/Commands/sub-classes/Manager.ts
@@ -555,7 +555,8 @@ export default class ManagerCommands {
                     );
                 }
 
-                const inventory = this.bot.inventoryManager;
+                const inventoryManager = this.bot.inventoryManager;
+                const inventory = inventoryManager.getInventory;
                 const isFilterCantAfford = opt.pricelist.filterCantAfford.enable;
 
                 this.bot.listingManager.listings.forEach(listing => {
@@ -581,7 +582,7 @@ export default class ManagerCommands {
                     const match = this.bot.pricelist.getPrice(listingSKU);
 
                     if (isFilterCantAfford && listing.intent === 0 && match !== null) {
-                        const canAffordToBuy = inventory.isCanAffordToBuy(match.buy, inventory.getInventory);
+                        const canAffordToBuy = inventoryManager.isCanAffordToBuy(match.buy, inventory);
 
                         if (!canAffordToBuy) {
                             // Listing for buying exist but we can't afford to buy, remove.
@@ -604,15 +605,14 @@ export default class ManagerCommands {
                     if (!isExist) {
                         // undefined - listing does not exist but item is in the pricelist
 
-                        // Get amountCanBuy and amountCanSell (already cover intent and so on)
-                        const amountCanBuy = inventory.amountCanTrade(entry.sku, true);
-                        const amountCanSell = inventory.amountCanTrade(entry.sku, false);
+                        // Get amountCanBuy (already cover intent and so on)
+                        const amountCanBuy = inventoryManager.amountCanTrade(entry.sku, true);
 
                         if (
-                            (amountCanBuy > 0 && inventory.isCanAffordToBuy(entry.buy, inventory.getInventory)) ||
-                            amountCanSell > 0
+                            (amountCanBuy > 0 && inventoryManager.isCanAffordToBuy(entry.buy, inventory)) ||
+                            inventory.getAmount(entry.sku, false, true) > 0
                         ) {
-                            // if can amountCanBuy is more than 0 and isCanAffordToBuy is true OR amountCanSell is more than 0
+                            // if can amountCanBuy is more than 0 and isCanAffordToBuy is true OR amount of item is more than 0
                             // return this entry
                             log.debug(
                                 `Missing${isFilterCantAfford ? '/Re-adding can afford' : ' listings'}: ${entry.sku}`

--- a/src/classes/Listings.ts
+++ b/src/classes/Listings.ts
@@ -350,14 +350,13 @@ export default class Listings {
                         // Filter pricelist to only items we can sell and we can afford to buy
 
                         const amountCanBuy = inventoryManager.amountCanTrade(entry.sku, true);
-                        const amountCanSell = inventoryManager.amountCanTrade(entry.sku, false);
 
                         if (
                             (amountCanBuy > 0 &&
                                 inventoryManager.isCanAffordToBuy(entry.buy, inventoryManager.getInventory)) ||
-                            amountCanSell > 0
+                            inventory.getAmount(entry.sku, false, true) > 0
                         ) {
-                            // if can amountCanBuy is more than 0 and isCanAffordToBuy is true OR amountCanSell is more than 0
+                            // if can amountCanBuy is more than 0 and isCanAffordToBuy is true OR amount of item is more than 0
                             // return this entry
                             return true;
                         }

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -556,7 +556,8 @@ export default class MyHandler extends Handler {
                         return;
                     }
 
-                    const inventory = this.bot.inventoryManager;
+                    const inventoryManager = this.bot.inventoryManager;
+                    const inventory = inventoryManager.getInventory;
                     const isFilterCantAfford = opt.pricelist.filterCantAfford.enable;
 
                     this.bot.listingManager.listings.forEach(listing => {
@@ -582,7 +583,7 @@ export default class MyHandler extends Handler {
                         const match = this.bot.pricelist.getPrice(listingSKU);
 
                         if (isFilterCantAfford && listing.intent === 0 && match !== null) {
-                            const canAffordToBuy = inventory.isCanAffordToBuy(match.buy, inventory.getInventory);
+                            const canAffordToBuy = inventoryManager.isCanAffordToBuy(match.buy, inventory);
                             if (!canAffordToBuy) {
                                 // Listing for buying exist but we can't afford to buy, remove.
                                 log.debug(`Intent buy, removed because can't afford: ${match.sku}`);
@@ -605,12 +606,11 @@ export default class MyHandler extends Handler {
                             // undefined - listing does not exist but item is in the pricelist
 
                             // Get amountCanBuy and amountCanSell (already cover intent and so on)
-                            const amountCanBuy = inventory.amountCanTrade(entry.sku, true);
-                            const amountCanSell = inventory.amountCanTrade(entry.sku, false);
+                            const amountCanBuy = inventoryManager.amountCanTrade(entry.sku, true);
 
                             if (
-                                (amountCanBuy > 0 && inventory.isCanAffordToBuy(entry.buy, inventory.getInventory)) ||
-                                amountCanSell > 0
+                                (amountCanBuy > 0 && inventoryManager.isCanAffordToBuy(entry.buy, inventory)) ||
+                                inventory.getAmount(entry.sku, false, true) > 0
                             ) {
                                 // if can amountCanBuy is more than 0 and isCanAffordToBuy is true OR amountCanSell is more than 0
                                 // return this entry


### PR DESCRIPTION
replace `amountCanSell` with only looking for the amount of an item, with `includeNonNormalize` set to `false`.