### PR TITLE
Add Trade Declined Summary

### DIFF
--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -21,6 +21,7 @@ import { UnknownDictionary } from '../../types/common';
 
 import { accepted, declined, cancelled, acceptEscrow, invalid } from './offer/notify/export-notify';
 import { processAccepted, updateListings, PriceCheckQueue } from './offer/accepted/exportAccepted';
+import processDeclined from './offer/processDeclined';
 import { sendReview } from './offer/review/export-review';
 import { keepMetalSupply, craftDuplicateWeapons, craftClassWeapons } from './utils/export-utils';
 
@@ -1929,6 +1930,16 @@ export default class MyHandler extends Handler {
                 highValue.isDisableSKU = result.isDisableSKU;
                 highValue.theirItems = result.theirHighValuedItems;
                 highValue.items = result.items;
+            } else if (
+                offer.state === TradeOfferManager.ETradeOfferState['Declined'] &&
+                this.bot.options.tradeDeclined.enable &&
+                !this.sentSummary[offer.id]
+            ) {
+                //No need to create a new timeout cause a trade can't be accepted after getting declined or cant be declined after being accepted.
+                clearTimeout(this.resetSentSummaryTimeout);
+                this.sentSummary[offer.id] = true;
+
+                processDeclined(offer, this.bot, this.isTradingKeys, timeTakenToComplete);
             }
         }
 

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -1932,7 +1932,7 @@ export default class MyHandler extends Handler {
                 highValue.items = result.items;
             } else if (
                 offer.state === TradeOfferManager.ETradeOfferState['Declined'] &&
-                this.bot.options.tradeDeclined.enable &&
+                this.bot.options.tradeSummary.declinedTrade.enable &&
                 !this.sentSummary[offer.id]
             ) {
                 //No need to create a new timeout cause a trade can't be accepted after getting declined or cant be declined after being accepted.

--- a/src/classes/MyHandler/offer/processDeclined.ts
+++ b/src/classes/MyHandler/offer/processDeclined.ts
@@ -5,7 +5,7 @@ import * as t from '../../../lib/tools/export';
 import sendTradeDeclined from 'src/lib/DiscordWebhook/sendTradeDeclined';
 import { KeyPrices } from 'src/classes/Pricelist';
 import Autokeys, { OverallStatus } from 'src/classes/Autokeys/Autokeys';
-import { TradeDeclined } from '../../Options';
+import { TradeSummary } from '../../Options';
 
 export default function processDeclined(
     offer: i.TradeOffer,
@@ -29,7 +29,7 @@ export default function processDeclined(
     const offerReceived = offer.data('action') as i.Action;
     const meta = offer.data('meta') as i.Meta;
 
-    const isWebhookEnabled = opt.discordWebhook.tradeDeclined.enable && opt.discordWebhook.tradeDeclined.url.length > 0;
+    const isWebhookEnabled = opt.discordWebhook.declinedTrade.enable && opt.discordWebhook.declinedTrade.url.length > 0;
 
     if (offerReceived) {
         switch (offerReceived.reason) {
@@ -193,7 +193,7 @@ export default function processDeclined(
             const autokeys = bot.handler.autokeys;
             const status = autokeys.getOverallStatus;
 
-            const tDec = bot.options.tradeDeclined;
+            const tDec = bot.options.tradeSummary;
             const cT = tDec.customText;
             const cTKeyRate = cT.keyRate.steamChat ? cT.keyRate.steamChat : '🔑 Key rate:';
             const cTPureStock = cT.pureStock.steamChat ? cT.pureStock.steamChat : '💰 Pure stock:';
@@ -246,7 +246,7 @@ export function sendToAdmin(
     cTTimeTaken: string,
     timeTakenToComplete: number,
     timeTakenToProcessOrConstruct: number,
-    tSum: TradeDeclined
+    tSum: TradeSummary
 ): void {
     bot.messageAdmins(
         'trade',

--- a/src/classes/MyHandler/offer/processDeclined.ts
+++ b/src/classes/MyHandler/offer/processDeclined.ts
@@ -1,0 +1,294 @@
+import * as i from '@tf2autobot/tradeoffer-manager';
+import SKU from 'tf2-sku-2';
+import Bot from '../../Bot';
+import * as t from '../../../lib/tools/export';
+import sendTradeDeclined from 'src/lib/DiscordWebhook/sendTradeDeclined';
+import { KeyPrices } from 'src/classes/Pricelist';
+import Autokeys, { OverallStatus } from 'src/classes/Autokeys/Autokeys';
+import { TradeDeclined } from '../../Options';
+
+export default function processDeclined(
+    offer: i.TradeOffer,
+    bot: Bot,
+    isTradingKeys: boolean,
+    timeTakenToComplete: number
+): void {
+    const opt = bot.options;
+
+    const declined: Declined = {
+        //nonTf2Items: [],
+        highNotSellingItems: [],
+        overstocked: [],
+        understocked: [],
+        invalidItems: [],
+        disabledItems: [],
+        dupedItems: [],
+        reasonDescription: ''
+    };
+
+    const offerReceived = offer.data('action') as i.Action;
+    const meta = offer.data('meta') as i.Meta;
+
+    const isWebhookEnabled = opt.discordWebhook.tradeDeclined.enable && opt.discordWebhook.tradeDeclined.url.length > 0;
+
+    if (offerReceived) {
+        switch (offerReceived.reason) {
+            case 'ESCROW':
+                declined.reasonDescription = offerReceived.reason + ': Partner has trade hold.';
+                break;
+            case 'BANNED':
+                declined.reasonDescription = offerReceived.reason + ': Partner is banned in one or more communities.';
+                break;
+            case '🟨_CONTAINS_NON_TF2':
+                declined.reasonDescription = offerReceived.reason + ': Trade includes non-TF2 items.';
+                //Maybe implement tags for them as well ?
+                break;
+            case 'GIFT_NO_NOTE':
+                declined.reasonDescription = offerReceived.reason + ': We dont accept gift without gift messages.';
+                break;
+            case 'CRIME_ATTEMPT':
+                declined.reasonDescription = offerReceived.reason + ': Tried to take our items for free.';
+                break;
+            case 'OVERPAY':
+                declined.reasonDescription = offerReceived.reason + ': We are not accepting overpay.';
+                break;
+            case 'DUELING_NOT_5_USES':
+                declined.reasonDescription = offerReceived.reason + ': We only accept 5 use Dueling Mini-Games.';
+                break;
+            case 'NOISE_MAKER_NOT_25_USES':
+                declined.reasonDescription = offerReceived.reason + ': We only accept 25 use Noise Makers.';
+                break;
+            case 'HIGH_VALUE_ITEMS_NOT_SELLING':
+                declined.reasonDescription =
+                    offerReceived.reason + ': Tried to take our high value items that we are not selling.';
+                //check our items to add tag
+                declined.highNotSellingItems.push(...meta.highValueName);
+                break;
+            case 'ONLY_METAL':
+                declined.reasonDescription = offerReceived.reason + ': Offer contains only metal.';
+                break;
+            case 'NOT_TRADING_KEYS':
+                declined.reasonDescription = offerReceived.reason + ': We are not trading keys.';
+                break;
+            case 'NOT_SELLING_KEYS':
+                declined.reasonDescription = offerReceived.reason + ': We are not selling keys.';
+                break;
+            case 'NOT_BUYING_KEYS':
+                declined.reasonDescription = offerReceived.reason + ': We are not buying keys.';
+                break;
+            case '🟥_INVALID_VALUE':
+                declined.reasonDescription = offerReceived.reason + ': We are paying more than them.';
+                break;
+            case '🟫_DUPED_ITEMS':
+                declined.reasonDescription = offerReceived.reason + ': Offer contains duped items.';
+                break;
+            case '🟦_OVERSTOCKED':
+                declined.reasonDescription =
+                    offerReceived.reason + ": Offer contains items that'll make us overstocked.";
+                break;
+            case '🟩_UNDERSTOCKED':
+                declined.reasonDescription =
+                    offerReceived.reason + ": Offer contains items that'll make us understocked.";
+                break;
+            case 'ONLY_INVALID_VALUE':
+            case 'ONLY_INVALID_ITEMS':
+            case 'ONLY_DISABLED_ITEMS':
+            case 'ONLY_OVERSTOCKED':
+            case 'ONLY_UNDERSTOCKED':
+                //It was probably faster to make them by hand but :/
+                declined.reasonDescription =
+                    offerReceived.reason +
+                    ': We are auto declining ' +
+                    offerReceived.reason
+                        .split('_')
+                        .slice(1)
+                        .join(' ')
+                        .toLowerCase()
+                        .replace(/(\b(?! ).)/g, char => char.toUpperCase());
+                break;
+        }
+        const checkedReasons = {};
+        meta?.uniqueReasons?.forEach(reason => {
+            if (checkedReasons[reason]) return;
+            checkedReasons[reason] = '.';
+            switch (reason) {
+                case '🟨_INVALID_ITEMS':
+                    (meta.reasons.filter(el => el.reason === '🟨_INVALID_ITEMS') as i.InvalidItems[]).forEach(el => {
+                        const name = t.testSKU(el.sku) ? bot.schema.getName(SKU.fromString(el.sku), false) : el.sku;
+
+                        declined.invalidItems.push(`${isWebhookEnabled ? `_${name}_` : name} - ${el.price}`);
+                    });
+                    break;
+                case '🟧_DISABLED_ITEMS':
+                    (meta.reasons.filter(el => el.reason == '🟧_DISABLED_ITEMS') as i.DisabledItems[]).forEach(el => {
+                        declined.disabledItems.push(
+                            isWebhookEnabled
+                                ? `_${bot.schema.getName(SKU.fromString(el.sku), false)}_`
+                                : bot.schema.getName(SKU.fromString(el.sku), false)
+                        );
+                    });
+                    break;
+                case '🟦_OVERSTOCKED':
+                    (meta.reasons.filter(el => el.reason.includes('🟦_OVERSTOCKED')) as i.Overstocked[]).forEach(el => {
+                        declined.overstocked.push(
+                            `${
+                                isWebhookEnabled
+                                    ? `_${bot.schema.getName(SKU.fromString(el.sku), false)}_`
+                                    : bot.schema.getName(SKU.fromString(el.sku), false)
+                            } (amount can buy was ${el.amountCanTrade}, offered ${el.amountOffered})`
+                        );
+                    });
+                    break;
+                case '🟩_UNDERSTOCKED':
+                    (meta.reasons.filter(el => el.reason.includes('🟩_UNDERSTOCKED')) as i.Understocked[]).forEach(
+                        el => {
+                            declined.understocked.push(
+                                `${
+                                    isWebhookEnabled
+                                        ? `_${bot.schema.getName(SKU.fromString(el.sku), false)}_`
+                                        : bot.schema.getName(SKU.fromString(el.sku), false)
+                                } (amount can sell was ${el.amountCanTrade}, taken ${el.amountTaking})`
+                            );
+                        }
+                    );
+                    break;
+                case '🟫_DUPED_ITEMS':
+                    (meta.reasons.filter(el => el.reason.includes('🟫_DUPED_ITEMS')) as i.DupedItems[]).forEach(el => {
+                        declined.dupedItems.push(
+                            isWebhookEnabled
+                                ? `_${bot.schema.getName(SKU.fromString(el.sku))}_`
+                                : bot.schema.getName(SKU.fromString(el.sku))
+                        );
+                    });
+                    break;
+            }
+        });
+
+        const timeTakenToProcessOrConstruct = (offer.data('constructOfferTime') ||
+            offer.data('processOfferTime')) as number;
+        if (isWebhookEnabled) {
+            void sendTradeDeclined(
+                offer,
+                declined,
+                bot,
+                timeTakenToComplete,
+                timeTakenToProcessOrConstruct,
+                isTradingKeys
+            );
+        } else {
+            const slots = bot.tf2.backpackSlots;
+            const itemsName = {
+                invalid: declined.invalidItems, // 🟨_INVALID_ITEMS
+                disabled: declined.disabledItems, // 🟧_DISABLED_ITEMS
+                overstock: declined.overstocked, // 🟦_OVERSTOCKED
+                understock: declined.understocked, // 🟩_UNDERSTOCKED
+                duped: declined.dupedItems, // '🟫_DUPED_ITEMS'
+                dupedFailed: [],
+                highValue: declined.highNotSellingItems
+            };
+            const keyPrices = bot.pricelist.getKeyPrices;
+            const value = t.valueDiff(offer, keyPrices, isTradingKeys, opt.miscSettings.showOnlyMetal.enable);
+            const itemList = t.listItems(offer, bot, itemsName, true);
+
+            const autokeys = bot.handler.autokeys;
+            const status = autokeys.getOverallStatus;
+
+            const tDec = bot.options.tradeDeclined;
+            const cT = tDec.customText;
+            const cTKeyRate = cT.keyRate.steamChat ? cT.keyRate.steamChat : '🔑 Key rate:';
+            const cTPureStock = cT.pureStock.steamChat ? cT.pureStock.steamChat : '💰 Pure stock:';
+            const cTTotalItems = cT.totalItems.steamChat ? cT.totalItems.steamChat : '🎒 Total items:';
+            const cTTimeTaken = cT.timeTaken.steamChat ? cT.timeTaken.steamChat : '⏱ Time taken:';
+
+            const customInitializer = bot.options.steamChat.customInitializer.declinedTradeSummary;
+            const isCustomPricer = bot.pricelist.isUseCustomPricer;
+
+            sendToAdmin(
+                bot,
+                offer,
+                customInitializer,
+                value,
+                itemList,
+                keyPrices,
+                false, //isOfferSent is unused for now
+                isCustomPricer,
+                cTKeyRate,
+                autokeys,
+                status,
+                slots,
+                cTPureStock,
+                cTTotalItems,
+                cTTimeTaken,
+                timeTakenToComplete,
+                timeTakenToProcessOrConstruct,
+                tDec
+            );
+        }
+    }
+    //else it's sent by us and they declined it so we don't care ?
+}
+
+export function sendToAdmin(
+    bot: Bot,
+    offer: i.TradeOffer,
+    customInitializer: string,
+    value: t.ValueDiff,
+    itemList: string,
+    keyPrices: KeyPrices,
+    isOfferSent: boolean,
+    isCustomPricer: boolean,
+    cTKeyRate: string,
+    autokeys: Autokeys,
+    status: OverallStatus,
+    slots: number,
+    cTPureStock: string,
+    cTTotalItems: string,
+    cTTimeTaken: string,
+    timeTakenToComplete: number,
+    timeTakenToProcessOrConstruct: number,
+    tSum: TradeDeclined
+): void {
+    bot.messageAdmins(
+        'trade',
+        `${customInitializer ? customInitializer : '/me'} Trade #${
+            offer.id
+        } with ${offer.partner.getSteamID64()} is declined. ❌` +
+            t.summarizeToChat(offer, bot, 'declined', false, value, keyPrices, true, isOfferSent) +
+            (itemList !== '-' ? `\n\nItem lists:\n${itemList}` : '') +
+            `\n\n${cTKeyRate} ${keyPrices.buy.toString()}/${keyPrices.sell.toString()}` +
+            ` (${keyPrices.src === 'manual' ? 'manual' : isCustomPricer ? 'custom-pricer' : 'prices.tf'})` +
+            `${
+                autokeys.isEnabled
+                    ? ' | Autokeys: ' +
+                      (autokeys.getActiveStatus
+                          ? '✅' +
+                            (status.isBankingKeys ? ' (banking)' : status.isBuyingKeys ? ' (buying)' : ' (selling)')
+                          : '🛑')
+                    : ''
+            }` +
+            `\n${cTPureStock} ${t.pure.stock(bot).join(', ').toString()}` +
+            `\n${cTTotalItems} ${bot.inventoryManager.getInventory.getTotalItems}${
+                slots !== undefined ? `/${slots}` : ''
+            }` +
+            `\n${cTTimeTaken} ${t.convertTime(
+                timeTakenToComplete,
+                timeTakenToProcessOrConstruct,
+                isOfferSent,
+                tSum.showDetailedTimeTaken,
+                tSum.showTimeTakenInMS
+            )}` +
+            `\n\nVersion ${process.env.BOT_VERSION}`,
+        []
+    );
+}
+
+interface Declined {
+    //nonTf2Items: string[];
+    highNotSellingItems: string[];
+    overstocked: string[];
+    understocked: string[];
+    invalidItems: string[];
+    disabledItems: string[];
+    dupedItems: string[];
+    reasonDescription: string;
+}

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -115,6 +115,7 @@ export const DEFAULTS: JsonOptions = {
     },
 
     tradeSummary: {
+        declinedTrade:{enable:false},
         showStockChanges: false,
         showTimeTakenInMS: false,
         showDetailedTimeTaken: true,
@@ -392,7 +393,6 @@ export const DEFAULTS: JsonOptions = {
         avatarURL: '',
         embedColor: '9171753',
         tradeSummary: {
-            declinedTrade:{enable:false},
             enable: true,
             url: [],
             misc: {
@@ -1123,7 +1123,6 @@ export interface TradeSummary {
     customText?: TradeSummaryCustomText;
 }
 
-
 interface TradeSummaryCustomText {
     summary: SteamDiscord;
     asked: SteamDiscord;
@@ -1370,7 +1369,6 @@ interface DiscordWebhook {
 }
 
 interface TradeSummaryDW extends OnlyEnable {
-    declinedTrade: OnlyEnable;
     url?: string[];
     misc?: MiscTradeSummary;
     mentionOwner?: MentionOwner;

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -408,6 +408,22 @@ export const DEFAULTS: JsonOptions = {
                 tradeValueInRef: 0
             }
         },
+        declinedTrades: {
+            enable: true,
+            url: [],
+            misc: {
+                showQuickLinks: true,
+                showKeyRate: true,
+                showPureStock: true,
+                showInventory: true,
+                note: ''
+            },
+            mentionOwner: {
+                enable: false,
+                itemSkus: [],
+                tradeValueInRef: 0
+            }
+        },
         offerReview: {
             enable: true,
             url: '',
@@ -1361,6 +1377,7 @@ interface DiscordWebhook {
     avatarURL?: string;
     embedColor?: string;
     tradeSummary?: TradeSummaryDW;
+    declinedTrades?: TradeSummaryDW;
     offerReview?: OfferReviewDW;
     messages?: MessagesDW;
     priceUpdate?: PriceUpdateDW;

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -6,7 +6,7 @@ import { deepMerge } from '../lib/tools/deep-merge';
 import validator from '../lib/validator';
 import { Currency } from '../types/TeamFortress2';
 
-export const DEFAULTS = {
+export const DEFAULTS: JsonOptions = {
     miscSettings: {
         showOnlyMetal: {
             enable: true
@@ -166,9 +166,62 @@ export const DEFAULTS = {
         }
     },
 
+    tradeDeclined: {
+        enable: false,
+        showStockChanges: false,
+        showTimeTakenInMS: false,
+        showDetailedTimeTaken: true,
+        showItemPrices: true,
+        showPureInEmoji: false,
+        showProperName: false,
+        customText: {
+            summary: {
+                steamChat: 'Summary',
+                discordWebhook: '__**Summary**__'
+            },
+            asked: {
+                steamChat: '• Asked:',
+                discordWebhook: '**• Asked:**'
+            },
+            offered: {
+                steamChat: '• Offered:',
+                discordWebhook: '**• Offered:**'
+            },
+            profitFromOverpay: {
+                steamChat: '📈 Profit from overpay:',
+                discordWebhook: '📈 ***Profit from overpay:***'
+            },
+            lossFromUnderpay: {
+                steamChat: '📉 Loss from underpay:',
+                discordWebhook: '📉 ***Loss from underpay:***'
+            },
+            timeTaken: {
+                steamChat: '⏱ Time taken:',
+                discordWebhook: '⏱ **Time taken:**'
+            },
+            keyRate: {
+                steamChat: '🔑 Key rate:',
+                discordWebhook: '🔑 Key rate:'
+            },
+            pureStock: {
+                steamChat: '💰 Pure stock:',
+                discordWebhook: '💰 Pure stock:'
+            },
+            totalItems: {
+                steamChat: '🎒 Total items:',
+                discordWebhook: '🎒 Total items:'
+            },
+            spells: '🎃 Spells:',
+            strangeParts: '🎰 Parts:',
+            killstreaker: '🔥 Killstreaker:',
+            sheen: '✨ Sheen:',
+            painted: '🎨 Painted:'
+        }
+    },
     steamChat: {
         customInitializer: {
             acceptedTradeSummary: '/me',
+            declinedTradeSummary: '/me',
             review: '',
             message: {
                 onReceive: '/quote',
@@ -392,6 +445,22 @@ export const DEFAULTS = {
         embedColor: '9171753',
         tradeSummary: {
             enable: true,
+            url: [],
+            misc: {
+                showQuickLinks: true,
+                showKeyRate: true,
+                showPureStock: true,
+                showInventory: true,
+                note: ''
+            },
+            mentionOwner: {
+                enable: false,
+                itemSkus: [],
+                tradeValueInRef: 0
+            }
+        },
+        tradeDeclined: {
+            enable: false,
             url: [],
             misc: {
                 showQuickLinks: true,
@@ -1120,6 +1189,11 @@ export interface TradeSummary {
     customText?: TradeSummaryCustomText;
 }
 
+export interface TradeDeclined extends TradeSummary {
+    enable?: boolean;
+    // Extends TradeSummary instead of copying values so if a psycho wants it they can make them both different.
+}
+
 interface TradeSummaryCustomText {
     summary: SteamDiscord;
     asked: SteamDiscord;
@@ -1150,6 +1224,7 @@ interface SteamChat {
 
 interface CustomInitializer {
     acceptedTradeSummary?: string;
+    declinedTradeSummary?: string;
     review?: string;
     message?: CustomInitializerMessage;
 }
@@ -1357,6 +1432,7 @@ interface DiscordWebhook {
     avatarURL?: string;
     embedColor?: string;
     tradeSummary?: TradeSummaryDW;
+    tradeDeclined: TradeSummaryDW;
     offerReview?: OfferReviewDW;
     messages?: MessagesDW;
     priceUpdate?: PriceUpdateDW;
@@ -1817,6 +1893,7 @@ export interface JsonOptions {
     pricelist?: Pricelist;
     bypass?: Bypass;
     tradeSummary?: TradeSummary;
+    tradeDeclined?: TradeDeclined;
     steamChat?: SteamChat;
     highValue?: HighValue;
     normalize?: Normalize;

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -166,58 +166,6 @@ export const DEFAULTS: JsonOptions = {
         }
     },
 
-    tradeDeclined: {
-        enable: false,
-        showStockChanges: false,
-        showTimeTakenInMS: false,
-        showDetailedTimeTaken: true,
-        showItemPrices: true,
-        showPureInEmoji: false,
-        showProperName: false,
-        customText: {
-            summary: {
-                steamChat: 'Summary',
-                discordWebhook: '__**Summary**__'
-            },
-            asked: {
-                steamChat: '• Asked:',
-                discordWebhook: '**• Asked:**'
-            },
-            offered: {
-                steamChat: '• Offered:',
-                discordWebhook: '**• Offered:**'
-            },
-            profitFromOverpay: {
-                steamChat: '📈 Profit from overpay:',
-                discordWebhook: '📈 ***Profit from overpay:***'
-            },
-            lossFromUnderpay: {
-                steamChat: '📉 Loss from underpay:',
-                discordWebhook: '📉 ***Loss from underpay:***'
-            },
-            timeTaken: {
-                steamChat: '⏱ Time taken:',
-                discordWebhook: '⏱ **Time taken:**'
-            },
-            keyRate: {
-                steamChat: '🔑 Key rate:',
-                discordWebhook: '🔑 Key rate:'
-            },
-            pureStock: {
-                steamChat: '💰 Pure stock:',
-                discordWebhook: '💰 Pure stock:'
-            },
-            totalItems: {
-                steamChat: '🎒 Total items:',
-                discordWebhook: '🎒 Total items:'
-            },
-            spells: '🎃 Spells:',
-            strangeParts: '🎰 Parts:',
-            killstreaker: '🔥 Killstreaker:',
-            sheen: '✨ Sheen:',
-            painted: '🎨 Painted:'
-        }
-    },
     steamChat: {
         customInitializer: {
             acceptedTradeSummary: '/me',
@@ -444,23 +392,8 @@ export const DEFAULTS: JsonOptions = {
         avatarURL: '',
         embedColor: '9171753',
         tradeSummary: {
+            declinedTrade:{enable:false},
             enable: true,
-            url: [],
-            misc: {
-                showQuickLinks: true,
-                showKeyRate: true,
-                showPureStock: true,
-                showInventory: true,
-                note: ''
-            },
-            mentionOwner: {
-                enable: false,
-                itemSkus: [],
-                tradeValueInRef: 0
-            }
-        },
-        tradeDeclined: {
-            enable: false,
             url: [],
             misc: {
                 showQuickLinks: true,
@@ -1180,6 +1113,7 @@ interface OnlyAllow {
 // ------------ TradeSummary ------------
 
 export interface TradeSummary {
+    declinedTrade?: OnlyEnable;
     showStockChanges?: boolean;
     showTimeTakenInMS?: boolean;
     showDetailedTimeTaken?: boolean;
@@ -1189,10 +1123,6 @@ export interface TradeSummary {
     customText?: TradeSummaryCustomText;
 }
 
-export interface TradeDeclined extends TradeSummary {
-    enable?: boolean;
-    // Extends TradeSummary instead of copying values so if a psycho wants it they can make them both different.
-}
 
 interface TradeSummaryCustomText {
     summary: SteamDiscord;
@@ -1432,7 +1362,6 @@ interface DiscordWebhook {
     avatarURL?: string;
     embedColor?: string;
     tradeSummary?: TradeSummaryDW;
-    tradeDeclined: TradeSummaryDW;
     offerReview?: OfferReviewDW;
     messages?: MessagesDW;
     priceUpdate?: PriceUpdateDW;
@@ -1441,6 +1370,7 @@ interface DiscordWebhook {
 }
 
 interface TradeSummaryDW extends OnlyEnable {
+    declinedTrade: OnlyEnable;
     url?: string[];
     misc?: MiscTradeSummary;
     mentionOwner?: MentionOwner;
@@ -1893,7 +1823,6 @@ export interface JsonOptions {
     pricelist?: Pricelist;
     bypass?: Bypass;
     tradeSummary?: TradeSummary;
-    tradeDeclined?: TradeDeclined;
     steamChat?: SteamChat;
     highValue?: HighValue;
     normalize?: Normalize;

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -115,7 +115,7 @@ export const DEFAULTS: JsonOptions = {
     },
 
     tradeSummary: {
-        declinedTrade:{enable:false},
+        declinedTrade: { enable: false },
         showStockChanges: false,
         showTimeTakenInMS: false,
         showDetailedTimeTaken: true,
@@ -408,7 +408,7 @@ export const DEFAULTS: JsonOptions = {
                 tradeValueInRef: 0
             }
         },
-        declinedTrades: {
+        declinedTrade: {
             enable: true,
             url: [],
             misc: {
@@ -1377,7 +1377,7 @@ interface DiscordWebhook {
     avatarURL?: string;
     embedColor?: string;
     tradeSummary?: TradeSummaryDW;
-    declinedTrades?: TradeSummaryDW;
+    declinedTrade?: TradeSummaryDW;
     offerReview?: OfferReviewDW;
     messages?: MessagesDW;
     priceUpdate?: PriceUpdateDW;

--- a/src/lib/DiscordWebhook/sendTradeDeclined.ts
+++ b/src/lib/DiscordWebhook/sendTradeDeclined.ts
@@ -1,0 +1,234 @@
+import { TradeOffer } from '@tf2autobot/tradeoffer-manager';
+import { getPartnerDetails, quickLinks, sendWebhook } from './utils';
+import Bot from '../../classes/Bot';
+import * as t from '../tools/export';
+import log from '../logger';
+import { Webhook } from './export';
+import { sendToAdmin } from '../../classes/MyHandler/offer/processDeclined';
+
+export default async function sendTradeDeclined(
+    offer: TradeOffer,
+    declined: Declined,
+    bot: Bot,
+    timeTakenToComplete: number,
+    timeTakenToProcessOrConstruct: number,
+    isTradingKeys: boolean
+): Promise<void> {
+    const optBot = bot.options;
+    const optDW = optBot.discordWebhook;
+
+    const properName = bot.options.tradeDeclined.showProperName;
+
+    //Unsure if highValue will work or not
+    const itemsName = properName
+        ? {
+              invalid: declined.invalidItems,
+              disabled: declined.disabledItems,
+              overstock: declined.overstocked,
+              understock: declined.understocked,
+              duped: declined.dupedItems,
+              dupedFailed: [],
+              highValue: declined.highNotSellingItems
+          }
+        : {
+              invalid: declined.invalidItems.map(name => t.replace.itemName(name)), // 🟨_INVALID_ITEMS
+              disabled: declined.disabledItems.map(name => t.replace.itemName(name)), // 🟧_DISABLED_ITEMS
+              overstock: declined.overstocked.map(name => t.replace.itemName(name)), // 🟦_OVERSTOCKED
+              understock: declined.understocked.map(name => t.replace.itemName(name)), // 🟩_UNDERSTOCKED
+              duped: declined.dupedItems.map(name => t.replace.itemName(name)), // '🟫_DUPED_ITEMS'
+              dupedFailed: [],
+              highValue: declined.highNotSellingItems.map(name => t.replace.itemName(name))
+          };
+
+    const keyPrices = bot.pricelist.getKeyPrices;
+    const value = t.valueDiff(offer, keyPrices, isTradingKeys, optBot.miscSettings.showOnlyMetal.enable);
+    const summary = t.summarizeToChat(offer, bot, 'declined', true, value, keyPrices, false);
+
+    log.debug('getting partner Avatar and Name...');
+    const details = await getPartnerDetails(offer, bot);
+
+    const botInfo = bot.handler.getBotInfo;
+    const links = t.generateLinks(offer.partner.toString());
+    const misc = optDW.tradeDeclined.misc;
+
+    const itemList = t.listItems(offer, bot, itemsName, false);
+    const slots = bot.tf2.backpackSlots;
+    const autokeys = bot.handler.autokeys;
+    const status = autokeys.getOverallStatus;
+
+    const tDec = optBot.tradeDeclined;
+    const cT = tDec.customText;
+    const cTTimeTaken = cT.timeTaken.discordWebhook ? cT.timeTaken.discordWebhook : '⏱ **Time taken:**';
+    const cTKeyRate = cT.keyRate.discordWebhook ? cT.keyRate.discordWebhook : '🔑 Key rate:';
+    const cTPureStock = cT.pureStock.discordWebhook ? cT.pureStock.discordWebhook : '💰 Pure stock:';
+    const cTTotalItems = cT.totalItems.discordWebhook ? cT.totalItems.discordWebhook : '🎒 Total items:';
+
+    const isCustomPricer = bot.pricelist.isUseCustomPricer;
+
+    const partnerNameNoFormat = t.replace.specialChar(details.personaName);
+
+    //Maybe mention owner on high value declines ?
+    const mentionOwner = '';
+    const declinedTradeSummary: Webhook = {
+        username: optDW.displayName ?? botInfo.name,
+        avatar_url: optDW.avatarURL ?? optDW.avatarURL,
+        content: mentionOwner,
+        embeds: [
+            {
+                color: optDW.embedColor,
+                author: {
+                    name: `${details.personaName}`,
+                    url: links.steam,
+                    icon_url: details.avatarFull as string
+                },
+                description:
+                    `⛔ An offer sent by ${partnerNameNoFormat} is declined.\nReason: ${declined.reasonDescription}\n` +
+                    summary +
+                    `\n${cTTimeTaken} ${t.convertTime(
+                        timeTakenToComplete,
+                        timeTakenToProcessOrConstruct,
+                        false, //Needs to be changed if we include our offers as well
+                        tDec.showDetailedTimeTaken,
+                        tDec.showTimeTakenInMS
+                    )}\n\n` +
+                    (misc.showQuickLinks ? `${quickLinks(partnerNameNoFormat, links)}\n` : '\n'),
+                fields: [
+                    {
+                        name: '__Item list__',
+                        value: itemList.replace(/@/g, '')
+                    },
+                    {
+                        name: `__Status__`,
+                        value:
+                            (misc.showKeyRate
+                                ? `\n${cTKeyRate} ${keyPrices.buy.metal.toString()}/${keyPrices.sell.metal.toString()} ref` +
+                                  ` (${
+                                      keyPrices.src === 'manual'
+                                          ? 'manual'
+                                          : isCustomPricer
+                                          ? 'custom-pricer'
+                                          : 'prices.tf'
+                                  })` +
+                                  `${
+                                      autokeys.isEnabled
+                                          ? ' | Autokeys: ' +
+                                            (autokeys.getActiveStatus
+                                                ? '✅' +
+                                                  (status.isBankingKeys
+                                                      ? ' (banking)'
+                                                      : status.isBuyingKeys
+                                                      ? ' (buying)'
+                                                      : ' (selling)')
+                                                : '🛑')
+                                          : ''
+                                  }`
+                                : '') +
+                            (misc.showPureStock ? `\n${cTPureStock} ${t.pure.stock(bot).join(', ').toString()}` : '') +
+                            (misc.showInventory
+                                ? `\n${cTTotalItems} ${bot.inventoryManager.getInventory.getTotalItems}${
+                                      slots !== undefined ? `/${slots}` : ''
+                                  }`
+                                : '') +
+                            (misc.note
+                                ? (misc.showKeyRate || misc.showPureStock || misc.showInventory ? '\n' : '') + misc.note
+                                : `\n[View my backpack](https://backpack.tf/profiles/${botInfo.steamID.getSteamID64()})`)
+                    }
+                ],
+                footer: {
+                    text: `#${offer.id} • ${offer.partner.toString()} • ${t.timeNow(bot.options).time} • v${
+                        process.env.BOT_VERSION
+                    }`
+                }
+            }
+        ]
+    };
+
+    if (itemList === '-' || itemList == '') {
+        // just remove the first element of the fields array (__Item list__)
+        declinedTradeSummary.embeds[0].fields.shift();
+    } else if (itemList.length >= 1024) {
+        // first get __Status__ element
+        const statusElement = declinedTradeSummary.embeds[0].fields.pop();
+
+        // now remove __Item list__, so now it should be empty
+        declinedTradeSummary.embeds[0].fields.length = 0;
+
+        const separate = itemList.split('@');
+        const separateCount = separate.length;
+
+        let newSentences = '';
+        let j = 1;
+        separate.forEach((sentence, i) => {
+            if ((newSentences.length >= 800 || i === separateCount - 1) && !(j > 4)) {
+                declinedTradeSummary.embeds[0].fields.push({
+                    name: `__Item list ${j}__`,
+                    value: newSentences.replace(/@/g, '')
+                });
+
+                if (i === separateCount - 1 || j > 4) {
+                    declinedTradeSummary.embeds[0].fields.push(statusElement);
+                }
+
+                newSentences = '';
+                j++;
+                //
+            } else newSentences += sentence;
+        });
+    }
+
+    const url = optDW.tradeDeclined.url;
+
+    url.forEach((link, i) => {
+        sendWebhook(link, declinedTradeSummary, 'trade-declined', i)
+            .then(() => log.debug(`✅ Sent summary (#${offer.id}) to Discord ${url.length > 1 ? `(${i + 1})` : ''}`))
+            .catch(err => {
+                log.debug(
+                    `❌ Failed to send trade-declined webhook (#${offer.id}) to Discord ${
+                        url.length > 1 ? `(${i + 1})` : ''
+                    }: `,
+                    err
+                );
+
+                const itemListx = t.listItems(offer, bot, itemsName, true);
+
+                const chatOpt = bot.options.tradeDeclined.customText;
+                const cTxKeyRate = chatOpt.keyRate.steamChat ? chatOpt.keyRate.steamChat : '🔑 Key rate:';
+                const cTxPureStock = chatOpt.pureStock.steamChat ? chatOpt.pureStock.steamChat : '💰 Pure stock:';
+                const cTxTotalItems = chatOpt.totalItems.steamChat ? chatOpt.totalItems.steamChat : '🎒 Total items:';
+                const cTxTimeTaken = chatOpt.timeTaken.steamChat ? chatOpt.timeTaken.steamChat : '⏱ Time taken:';
+
+                //Not so sure about this if something goes wrong with discord and we get a lot of trades it'll be un🐻able
+                sendToAdmin(
+                    bot,
+                    offer,
+                    optBot.steamChat.customInitializer.declinedTradeSummary,
+                    value,
+                    itemListx,
+                    keyPrices,
+                    false, //isOfferSent is unused for now
+                    isCustomPricer,
+                    cTxKeyRate,
+                    autokeys,
+                    status,
+                    slots,
+                    cTxPureStock,
+                    cTxTotalItems,
+                    cTxTimeTaken,
+                    timeTakenToComplete,
+                    timeTakenToProcessOrConstruct,
+                    tDec
+                );
+            });
+    });
+}
+
+interface Declined {
+    //nonTf2Items: string[];
+    highNotSellingItems: string[];
+    overstocked: string[];
+    understocked: string[];
+    invalidItems: string[];
+    disabledItems: string[];
+    dupedItems: string[];
+    reasonDescription: string;
+}

--- a/src/lib/DiscordWebhook/sendTradeDeclined.ts
+++ b/src/lib/DiscordWebhook/sendTradeDeclined.ts
@@ -17,7 +17,7 @@ export default async function sendTradeDeclined(
     const optBot = bot.options;
     const optDW = optBot.discordWebhook;
 
-    const properName = bot.options.tradeDeclined.showProperName;
+    const properName = bot.options.tradeSummary.showProperName;
 
     //Unsure if highValue will work or not
     const itemsName = properName
@@ -49,14 +49,14 @@ export default async function sendTradeDeclined(
 
     const botInfo = bot.handler.getBotInfo;
     const links = t.generateLinks(offer.partner.toString());
-    const misc = optDW.tradeDeclined.misc;
+    const misc = optDW.declinedTrade.misc;
 
     const itemList = t.listItems(offer, bot, itemsName, false);
     const slots = bot.tf2.backpackSlots;
     const autokeys = bot.handler.autokeys;
     const status = autokeys.getOverallStatus;
 
-    const tDec = optBot.tradeDeclined;
+    const tDec = optBot.tradeSummary;
     const cT = tDec.customText;
     const cTTimeTaken = cT.timeTaken.discordWebhook ? cT.timeTaken.discordWebhook : '⏱ **Time taken:**';
     const cTKeyRate = cT.keyRate.discordWebhook ? cT.keyRate.discordWebhook : '🔑 Key rate:';
@@ -171,12 +171,11 @@ export default async function sendTradeDeclined(
 
                 newSentences = '';
                 j++;
-                //
             } else newSentences += sentence;
         });
     }
 
-    const url = optDW.tradeDeclined.url;
+    const url = optDW.declinedTrade.url;
 
     url.forEach((link, i) => {
         sendWebhook(link, declinedTradeSummary, 'trade-declined', i)
@@ -191,7 +190,7 @@ export default async function sendTradeDeclined(
 
                 const itemListx = t.listItems(offer, bot, itemsName, true);
 
-                const chatOpt = bot.options.tradeDeclined.customText;
+                const chatOpt = bot.options.tradeSummary.customText;
                 const cTxKeyRate = chatOpt.keyRate.steamChat ? chatOpt.keyRate.steamChat : '🔑 Key rate:';
                 const cTxPureStock = chatOpt.pureStock.steamChat ? chatOpt.pureStock.steamChat : '💰 Pure stock:';
                 const cTxTotalItems = chatOpt.totalItems.steamChat ? chatOpt.totalItems.steamChat : '🎒 Total items:';

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -1254,6 +1254,56 @@ export const optionsSchema: jsonschema.Schema = {
                     required: ['enable', 'url', 'misc', 'mentionOwner'],
                     additionalProperties: false
                 },
+                declinedTrades: {
+                    properties: {
+                        enable: {
+                            type: 'boolean'
+                        },
+                        url: {
+                            $ref: 'array-string-url'
+                        },
+                        misc: {
+                            type: 'object',
+                            properties: {
+                                showQuickLinks: {
+                                    type: 'boolean'
+                                },
+                                showKeyRate: {
+                                    type: 'boolean'
+                                },
+                                showPureStock: {
+                                    type: 'boolean'
+                                },
+                                showInventory: {
+                                    type: 'boolean'
+                                },
+                                note: {
+                                    type: 'string'
+                                }
+                            },
+                            required: ['showQuickLinks', 'showKeyRate', 'showPureStock', 'showInventory', 'note'],
+                            additionalProperties: false
+                        },
+                        mentionOwner: {
+                            properties: {
+                                enable: {
+                                    type: 'boolean'
+                                },
+                                itemSkus: {
+                                    $ref: '#/definitions/string-array'
+                                },
+                                tradeValueInRef: {
+                                    type: 'number',
+                                    minimum: 0
+                                }
+                            },
+                            required: ['enable', 'itemSkus', 'tradeValueInRef'],
+                            additionalProperties: false
+                        }
+                    },
+                    required: ['enable', 'url', 'misc', 'mentionOwner'],
+                    additionalProperties: false
+                },
                 offerReview: {
                     type: 'object',
                     properties: {

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -583,6 +583,15 @@ export const optionsSchema: jsonschema.Schema = {
         tradeSummary: {
             type: 'object',
             properties: {
+                declinedTrade: {
+                    type: 'object',
+                    properties: {
+                        enable: {
+                            type: 'boolean'
+                        }
+                    },
+                    required:['enable']
+                },
                 showStockChanges: {
                     type: 'boolean'
                 },
@@ -667,6 +676,7 @@ export const optionsSchema: jsonschema.Schema = {
                 }
             },
             required: [
+                'declinedTrade',
                 'showStockChanges',
                 'showTimeTakenInMS',
                 'showDetailedTimeTaken',
@@ -686,6 +696,9 @@ export const optionsSchema: jsonschema.Schema = {
                         acceptedTradeSummary: {
                             $ref: '#/definitions/valid-initializer'
                         },
+                        declinedTradeSummary: {
+                            $ref: '#/definitions/valid-initializer'
+                        },
                         review: {
                             $ref: '#/definitions/valid-initializer'
                         },
@@ -703,7 +716,7 @@ export const optionsSchema: jsonschema.Schema = {
                             additionalProperties: false
                         }
                     },
-                    required: ['acceptedTradeSummary', 'review', 'message'],
+                    required: ['acceptedTradeSummary', 'declinedTradeSummary', 'review', 'message'],
                     additionalProperties: false
                 }
             },

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -590,7 +590,7 @@ export const optionsSchema: jsonschema.Schema = {
                             type: 'boolean'
                         }
                     },
-                    required:['enable']
+                    required: ['enable']
                 },
                 showStockChanges: {
                     type: 'boolean'
@@ -1254,7 +1254,7 @@ export const optionsSchema: jsonschema.Schema = {
                     required: ['enable', 'url', 'misc', 'mentionOwner'],
                     additionalProperties: false
                 },
-                declinedTrades: {
+                declinedTrade: {
                     properties: {
                         enable: {
                             type: 'boolean'
@@ -1413,6 +1413,7 @@ export const optionsSchema: jsonschema.Schema = {
                 'avatarURL',
                 'embedColor',
                 'tradeSummary',
+                'declinedTrade',
                 'offerReview',
                 'messages',
                 'priceUpdate',


### PR DESCRIPTION
adds ability to receive declined trade summaries.

Sends Discord Webhook message or Steam message on declined offers.
Uses webhook `trade-declined`.
Message includes the reason and the description about why the trade was declined.
Adds new option to `options.json` called tradeDeclined

Fixes: https://github.com/TF2Autobot/tf2autobot/issues/582