### PR TITLE
🔨 standardize defindex for Mann Co. Stockpile Crate

### DIFF
--- a/src/classes/Commands/functions/utils.ts
+++ b/src/classes/Commands/functions/utils.ts
@@ -318,6 +318,9 @@ export function getItemFromParams(
     ) {
         // Standardize all specific Basic Killstreak Kit
         item.defindex = 6527;
+    } else if (item.defindex === 5738) {
+        // Standardize different versions of Mann Co. Stockpile Crate
+        item.defindex = 5737;
     }
 
     if (typeof params.quality === 'number') {

--- a/src/lib/items.ts
+++ b/src/lib/items.ts
@@ -61,6 +61,9 @@ export function fixItem(item: MinimumItem, schema: SchemaManager.Schema): Minimu
     ) {
         // Standardize all specific Basic Killstreak Kit
         item.defindex = 6527;
+    } else if (item.defindex === 5738) {
+        // Standardize different versions of Mann Co. Stockpile Crate
+        item.defindex = 5737;
     }
 
     const isPromo = isPromoItem(schemaItem);


### PR DESCRIPTION
Looks the same, but different defindex:
![image](https://user-images.githubusercontent.com/47635037/117567332-6f3e7000-b0ee-11eb-834f-7014db864504.png)

- If you already added the one with 5737, then you'll not be able to add 5738.