### PR TITLE
fix migration crashing with limited options.json

### DIFF
--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -2048,56 +2048,60 @@ function replaceOldProperties(options: Options): boolean {
 
     // <= v4.1.5 → v4.2.0
     const hv = options.highValue;
-    const spells = hv.spells;
-    if (Array.isArray(spells)) {
-        options.highValue.spells = {
-            names: spells,
-            exceptionSkus: []
-        };
-        isChanged = true;
-    }
+    if (hv) {
+        const spells = hv.spells;
+        if (Array.isArray(spells)) {
+            options.highValue.spells = {
+                names: spells,
+                exceptionSkus: []
+            };
+            isChanged = true;
+        }
 
-    const sheens = hv.sheens;
-    if (Array.isArray(sheens)) {
-        options.highValue.sheens = {
-            names: sheens,
-            exceptionSkus: []
-        };
-        isChanged = true;
-    }
+        const sheens = hv.sheens;
+        if (Array.isArray(sheens)) {
+            options.highValue.sheens = {
+                names: sheens,
+                exceptionSkus: []
+            };
+            isChanged = true;
+        }
 
-    const killstreakers = hv.killstreakers;
-    if (Array.isArray(killstreakers)) {
-        options.highValue.killstreakers = {
-            names: killstreakers,
-            exceptionSkus: []
-        };
-        isChanged = true;
-    }
+        const killstreakers = hv.killstreakers;
+        if (Array.isArray(killstreakers)) {
+            options.highValue.killstreakers = {
+                names: killstreakers,
+                exceptionSkus: []
+            };
+            isChanged = true;
+        }
 
-    const strangeParts = hv.strangeParts;
-    if (Array.isArray(strangeParts)) {
-        options.highValue.strangeParts = {
-            names: strangeParts,
-            exceptionSkus: []
-        };
-        isChanged = true;
-    }
+        const strangeParts = hv.strangeParts;
+        if (Array.isArray(strangeParts)) {
+            options.highValue.strangeParts = {
+                names: strangeParts,
+                exceptionSkus: []
+            };
+            isChanged = true;
+        }
 
-    const painted = hv.painted;
-    if (Array.isArray(painted)) {
-        options.highValue.painted = {
-            names: painted,
-            exceptionSkus: []
-        };
-        isChanged = true;
+        const painted = hv.painted;
+        if (Array.isArray(painted)) {
+            options.highValue.painted = {
+                names: painted,
+                exceptionSkus: []
+            };
+            isChanged = true;
+        }
     }
 
     // <= v4.2.0 → v4.2.1
-    const ownerID = options.discordWebhook.ownerID;
-    if (!Array.isArray(ownerID)) {
-        options.discordWebhook.ownerID = [ownerID];
-        isChanged = true;
+    if (options.discordWebhook) {
+        const ownerID = options.discordWebhook.ownerID;
+        if (!Array.isArray(ownerID)) {
+            options.discordWebhook.ownerID = [ownerID];
+            isChanged = true;
+        }
     }
 
     return isChanged;

--- a/src/classes/__tests__/Options.ts
+++ b/src/classes/__tests__/Options.ts
@@ -154,3 +154,18 @@ test('loads prices.tf options', () => {
     result = Options.loadOptions({ steamAccountName: 'abc123', customPricerUrl: 'alternative.tf' });
     expect(result.customPricerUrl).toEqual('alternative.tf');
 });
+
+test('loads a subset of options', () => {
+    const filesPath = Options.getFilesPath('abc123');
+    cleanPath(filesPath);
+    const rawOptions = '{"miscSettings":{"addFriends":{"enable":false},"sendGroupInvite":{"enable":false}}}';
+    const optionsFilePath = path.join(filesPath, 'options.json');
+    mkdirSync(filesPath, { recursive: true });
+    writeFileSync(optionsFilePath, rawOptions, { encoding: 'utf8' });
+    const result = Options.loadOptions({
+        steamAccountName: 'abc123',
+        miscSettings: { addFriends: { enable: false }, sendGroupInvite: { enable: false } }
+    });
+    expect(result.miscSettings.addFriends.enable).toBeFalsy();
+    expect(result.miscSettings.sendGroupInvite.enable).toBeFalsy();
+});


### PR DESCRIPTION
If a user has a subset of options.json the assumption of keys being present in replaceOldProperties can cause crashes.