### PR TITLE
🐛 fix unable to sell not-full uses items

### DIFF
--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -854,11 +854,14 @@ export default class MyHandler extends Handler {
                     } else if (item.isFullUses !== undefined) {
                         getHighValue[which].items[sku] = { isFull: item.isFullUses };
 
-                        if (sku === '241;6' && item.isFullUses === false) {
-                            isDuelingNotFullUses = true;
-                        } else if (noiseMakers.has(sku) && item.isFullUses === false) {
-                            isNoiseMakerNotFullUses = true;
-                            noiseMakerNotFullSKUs.push(sku);
+                        if (which === 'their') {
+                            // Only check for their side
+                            if (sku === '241;6' && item.isFullUses === false) {
+                                isDuelingNotFullUses = true;
+                            } else if (noiseMakers.has(sku) && item.isFullUses === false) {
+                                isNoiseMakerNotFullUses = true;
+                                noiseMakerNotFullSKUs.push(sku);
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
If your `miscSettings.checkUses.duel` or `miscSettings.checkUses.noiseMaker` is set to `true`, then if your bot has any of it that is not full use (5x uses or 25x uses), the bot will decline the trade, even though it's on your bot side.

![image](https://user-images.githubusercontent.com/47635037/123688790-07eaa400-d885-11eb-99f2-7188dcb965c4.png)
![image](https://user-images.githubusercontent.com/47635037/123691305-09699b80-d888-11eb-9733-4f1b9dacd264.png)


So this should fix it.