### PR TITLE
💡 refactor handling offer review

### DIFF
--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -1015,7 +1015,11 @@ export default class MyHandler extends Handler {
                     };
                 } else {
                     offer.log('info', 'is a gift offer without any offer message, declining...');
-                    return { action: 'decline', reason: 'GIFT_NO_NOTE' };
+                    return {
+                        action: 'decline',
+                        reason: 'GIFT_NO_NOTE',
+                        meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
+                    };
                 }
             }
         } else if (
@@ -1024,7 +1028,11 @@ export default class MyHandler extends Handler {
             !(opt.miscSettings.counterOffer.enable && exchange.contains.items)
         ) {
             offer.log('info', 'is taking our items for free, declining...');
-            return { action: 'decline', reason: 'CRIME_ATTEMPT' };
+            return {
+                action: 'decline',
+                reason: 'CRIME_ATTEMPT',
+                meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
+            };
         }
 
         // Check for Dueling Mini-Game and/or Noise maker for 5x/25x Uses only when enabled
@@ -1036,7 +1044,11 @@ export default class MyHandler extends Handler {
             if (checkExist.getPrice('241;6', true) !== null) {
                 // Dueling Mini-Game: Only decline if exist in pricelist
                 offer.log('info', 'contains Dueling Mini-Game that does not have 5 uses.');
-                return { action: 'decline', reason: 'DUELING_NOT_5_USES' };
+                return {
+                    action: 'decline',
+                    reason: 'DUELING_NOT_5_USES',
+                    meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
+                };
             }
         }
 
@@ -1045,7 +1057,11 @@ export default class MyHandler extends Handler {
             if (isHasNoiseMaker) {
                 // Noise Maker: Only decline if exist in pricelist
                 offer.log('info', 'contains Noise Maker that does not have 25 uses.');
-                return { action: 'decline', reason: 'NOISE_MAKER_NOT_25_USES' };
+                return {
+                    action: 'decline',
+                    reason: 'NOISE_MAKER_NOT_25_USES',
+                    meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
+                };
             }
         }
 
@@ -1490,7 +1506,11 @@ export default class MyHandler extends Handler {
 
         if (exchange.our.value < exchange.their.value && !opt.bypass.overpay.allow) {
             offer.log('info', 'is offering more than needed, declining...');
-            return { action: 'decline', reason: 'OVERPAY' };
+            return {
+                action: 'decline',
+                reason: 'OVERPAY',
+                meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
+            };
         }
 
         const assetidsToCheckCount = assetidsToCheck.length;
@@ -1555,7 +1575,11 @@ export default class MyHandler extends Handler {
 
             if (hasEscrow) {
                 offer.log('info', 'would be held if accepted, declining...');
-                return { action: 'decline', reason: 'ESCROW' };
+                return {
+                    action: 'decline',
+                    reason: 'ESCROW',
+                    meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
+                };
             }
         } catch (err) {
             log.warn('Failed to check escrow: ', err);
@@ -1578,7 +1602,11 @@ export default class MyHandler extends Handler {
                     } else log.debug(`✅ Successfully blocked user ${offer.partner.getSteamID64()}`);
                 });
 
-                return { action: 'decline', reason: 'BANNED' };
+                return {
+                    action: 'decline',
+                    reason: 'BANNED',
+                    meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
+                };
             }
         } catch (err) {
             log.error('Failed to check banned: ', err);
@@ -1852,22 +1880,22 @@ export default class MyHandler extends Handler {
                 }
 
                 // If only 🟥_INVALID_VALUE and did not matched exception value, will just decline the trade.
-                return { action: 'decline', reason: 'ONLY_INVALID_VALUE' };
+                return { action: 'decline', reason: 'ONLY_INVALID_VALUE', meta: meta };
             } else if (opt.offerReceived.invalidItems.autoDecline.enable && isOnlyInvalidItem) {
                 // If only 🟨_INVALID_ITEMS and Auto-decline INVALID_ITEMS enabled, will just decline the trade.
-                return { action: 'decline', reason: 'ONLY_INVALID_ITEMS' };
+                return { action: 'decline', reason: 'ONLY_INVALID_ITEMS', meta: meta };
             } else if (opt.offerReceived.disabledItems.autoDecline.enable && isOnlyDisabledItem) {
                 // If only 🟧_DISABLED_ITEMS (and with 🟥_INVALID_VALUE)
                 // and Auto-decline DISABLED_ITEMS enabled, will just decline the trade.
-                return { action: 'decline', reason: 'ONLY_DISABLED_ITEMS' };
+                return { action: 'decline', reason: 'ONLY_DISABLED_ITEMS', meta: meta };
             } else if (opt.offerReceived.overstocked.autoDecline.enable && isOnlyOverstocked) {
                 // If only 🟦_OVERSTOCKED (and with 🟥_INVALID_VALUE)
                 // and Auto-decline OVERSTOCKED enabled, will just decline the trade.
-                return { action: 'decline', reason: 'ONLY_OVERSTOCKED' };
+                return { action: 'decline', reason: 'ONLY_OVERSTOCKED', meta: meta };
             } else if (opt.offerReceived.understocked.autoDecline.enable && isOnlyUnderstocked) {
                 // If only 🟩_UNDERSTOCKED (and with 🟥_INVALID_VALUE)
                 // and Auto-decline UNDERSTOCKED enabled, will just decline the trade.
-                return { action: 'decline', reason: 'ONLY_UNDERSTOCKED' };
+                return { action: 'decline', reason: 'ONLY_UNDERSTOCKED', meta: meta };
             } else if (opt.offerReceived.duped.autoDecline.enable && isOnlyDupedItem) {
                 // If only 🟫_DUPED_ITEMS (and with 🟥_INVALID_VALUE)
                 // and Auto-decline DUPED_ITEMS enabled, will just decline the trade.

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -1495,8 +1495,6 @@ export default class MyHandler extends Handler {
 
         const assetidsToCheckCount = assetidsToCheck.length;
 
-        let metaDupedItem: Meta;
-
         if (this.dupeCheckEnabled && assetidsToCheckCount > 0) {
             offer.log('info', 'checking ' + pluralize('item', assetidsToCheckCount, true) + ' for dupes...');
             const inventory = new TF2Inventory(offer.partner, this.bot.manager);
@@ -1523,7 +1521,6 @@ export default class MyHandler extends Handler {
                     if (result[i] === true) {
                         // Found duped item
                         // Offer contains duped items but we don't decline duped items, instead add it to the wrong about offer list and continue
-                        metaDupedItem = { assetids: assetidsToCheck, sku: skuToCheck, result: result };
                         wrongAboutOffer.push({
                             reason: '🟫_DUPED_ITEMS',
                             assetid: assetidsToCheck[i],
@@ -1877,7 +1874,7 @@ export default class MyHandler extends Handler {
                 return {
                     action: 'decline',
                     reason: 'ONLY_DUPED_ITEM',
-                    meta: metaDupedItem
+                    meta: meta
                 };
             } else if (opt.offerReceived.failedToCheckDuped.autoDecline.enable && isOnlyFailedToCheckDupedItem) {
                 // If only 🟪_DUPE_CHECK_FAILED (and with 🟥_INVALID_VALUE)
@@ -1943,7 +1940,7 @@ export default class MyHandler extends Handler {
                     return {
                         action: 'decline',
                         reason: '🟫_DUPED_ITEMS',
-                        meta: metaDupedItem
+                        meta: meta
                     };
                 } else if (hasDupedCheckFailed) {
                     offer.log('info', 'failed to check for duped item, declining...');

--- a/src/classes/MyHandler/offer/processDeclined.ts
+++ b/src/classes/MyHandler/offer/processDeclined.ts
@@ -60,7 +60,7 @@ export default function processDeclined(offer: i.TradeOffer, bot: Bot, isTrading
                 declined.reasonDescription =
                     offerReceived.reason + ': Tried to take our high value items that we are not selling.';
                 //check our items to add tag
-                declined.highNotSellingItems.push(...meta?.highValueName);
+                if (meta?.highValueName) declined.highNotSellingItems.push(...meta.highValueName);
                 break;
             case 'ONLY_METAL':
                 declined.reasonDescription = offerReceived.reason + ': Offer contains only metal.';

--- a/src/classes/MyHandler/offer/processDeclined.ts
+++ b/src/classes/MyHandler/offer/processDeclined.ts
@@ -72,17 +72,6 @@ export default function processDeclined(offer: i.TradeOffer, bot: Bot, isTrading
             case 'NOT_BUYING_KEYS':
                 declined.reasonDescription = offerReceived.reason + ': We are not buying keys.';
                 break;
-            case '🟥_INVALID_VALUE':
-                declined.reasonDescription = offerReceived.reason + ': We are paying more than them.';
-                break;
-            case 'COUNTER_INVALID_VALUE_FAILED':
-                declined.reasonDescription =
-                    offerReceived.reason +
-                    ': We are paying more than them and we failed to counter the offer, or Steam might be down, or private inventory (failed to load their inventory).';
-                break;
-            case '🟫_DUPED_ITEMS':
-                declined.reasonDescription = offerReceived.reason + ': Offer contains duped items.';
-                break;
             case '🟦_OVERSTOCKED':
                 declined.reasonDescription =
                     offerReceived.reason + ": Offer contains items that'll make us overstocked.";
@@ -90,6 +79,30 @@ export default function processDeclined(offer: i.TradeOffer, bot: Bot, isTrading
             case '🟩_UNDERSTOCKED':
                 declined.reasonDescription =
                     offerReceived.reason + ": Offer contains items that'll make us understocked.";
+                break;
+            case '🟧_DISABLED_ITEMS':
+                declined.reasonDescription = offerReceived.reason + ': Offer contains disabled items.';
+                break;
+            case '🟨_INVALID_ITEMS':
+                declined.reasonDescription = offerReceived.reason + ': Offer contains invalid items.';
+                break;
+            case '🟫_DUPED_ITEMS':
+                declined.reasonDescription = offerReceived.reason + ': Offer contains duped items.';
+                break;
+            case '🟪_DUPE_CHECK_FAILED':
+                declined.reasonDescription =
+                    offerReceived.reason +
+                    `: Offer contains item(s) that is worth more than ${opt.offerReceived.duped.minKeys} keys, and I was unable ` +
+                    `to determine if this item is duped or not. Please make sure your inventory is public, and your backpack.tf inventory ` +
+                    `is refreshed with no fallback mode and try again later.`;
+                break;
+            case '🟥_INVALID_VALUE':
+                declined.reasonDescription = offerReceived.reason + ': We are paying more than them.';
+                break;
+            case 'COUNTER_INVALID_VALUE_FAILED':
+                declined.reasonDescription =
+                    offerReceived.reason +
+                    ': We are paying more than them and we failed to counter the offer, or Steam might be down, or private inventory (failed to load their inventory).';
                 break;
             case 'ONLY_INVALID_VALUE':
             case 'ONLY_INVALID_ITEMS':

--- a/src/classes/MyHandler/offer/processDeclined.ts
+++ b/src/classes/MyHandler/offer/processDeclined.ts
@@ -96,6 +96,8 @@ export default function processDeclined(offer: i.TradeOffer, bot: Bot, isTrading
             case 'ONLY_DISABLED_ITEMS':
             case 'ONLY_OVERSTOCKED':
             case 'ONLY_UNDERSTOCKED':
+            case 'ONLY_DUPED_ITEM':
+            case 'ONLY_DUPE_CHECK_FAILED':
                 //It was probably faster to make them by hand but :/
                 declined.reasonDescription =
                     offerReceived.reason +

--- a/src/classes/MyHandler/offer/review/send-review.ts
+++ b/src/classes/MyHandler/offer/review/send-review.ts
@@ -99,6 +99,18 @@ export default async function sendReview(
                 highValueItems.push(`${isWebhookEnabled ? `_${name}_` : name}` + itemsName[name]);
             }
         }
+
+        if (Object.keys(meta.highValue.items.our).length > 0) {
+            const itemsName = t.getHighValueItems(meta.highValue.items.our, bot, bot.paints, bot.strangeParts);
+
+            for (const name in itemsName) {
+                if (!Object.prototype.hasOwnProperty.call(itemsName, name)) {
+                    continue;
+                }
+
+                highValueItems.push(`${isWebhookEnabled ? `_${name}_` : name}` + itemsName[name]);
+            }
+        }
     }
 
     const items = {

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -1540,7 +1540,7 @@ interface AcceptedNote {
     manual?: OfferType;
 }
 
-interface OfferType {
+export interface OfferType {
     largeOffer: string;
     smallOffer: string;
 }

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -364,6 +364,13 @@ export const DEFAULTS: JsonOptions = {
                 declineReply: ''
             }
         },
+        // 🟪_DUPE_CHECK_FAILED
+        failedToCheckDuped: {
+            autoDecline: {
+                enable: false,
+                declineReply: ''
+            }
+        },
         // ⬜_ESCROW_CHECK_FAILED
         escrowCheckFailed: {
             ignoreFailed: false
@@ -1366,6 +1373,7 @@ interface OfferReceived {
     overstocked?: AutoAcceptOverpayAndAutoDecline;
     understocked?: AutoAcceptOverpayAndAutoDecline;
     duped?: Duped;
+    failedToCheckDuped: FailedToCheckDuped;
     escrowCheckFailed?: EscrowBannedCheckFailed;
     bannedCheckFailed?: EscrowBannedCheckFailed;
 }
@@ -1396,6 +1404,10 @@ interface InvalidItems extends AutoAcceptOverpayAndAutoDecline {
 interface Duped {
     enableCheck?: boolean;
     minKeys?: number;
+    autoDecline?: DeclineReply;
+}
+
+interface FailedToCheckDuped {
     autoDecline?: DeclineReply;
 }
 

--- a/src/lib/DiscordWebhook/sendTradeDeclined.ts
+++ b/src/lib/DiscordWebhook/sendTradeDeclined.ts
@@ -22,7 +22,6 @@ export default async function sendTradeDeclined(
     const isCountered: boolean = (offer.data('action') as Action)?.action === 'counter';
     const processCounterTime: number | undefined = offer.data('processCounterTime') as number;
 
-    //Unsure if highValue will work or not
     const itemsName = properName
         ? {
               invalid: declined.invalidItems,
@@ -31,7 +30,7 @@ export default async function sendTradeDeclined(
               understock: declined.understocked,
               duped: declined.dupedItems,
               dupedFailed: [],
-              highValue: declined.highNotSellingItems
+              highValue: declined.highValue.concat(declined.highNotSellingItems)
           }
         : {
               invalid: declined.invalidItems.map(name => t.replace.itemName(name)), // 🟨_INVALID_ITEMS
@@ -40,7 +39,7 @@ export default async function sendTradeDeclined(
               understock: declined.understocked.map(name => t.replace.itemName(name)), // 🟩_UNDERSTOCKED
               duped: declined.dupedItems.map(name => t.replace.itemName(name)), // '🟫_DUPED_ITEMS'
               dupedFailed: [],
-              highValue: declined.highNotSellingItems.map(name => t.replace.itemName(name))
+              highValue: declined.highValue.concat(declined.highNotSellingItems).map(name => t.replace.itemName(name))
           };
 
     const keyPrices = bot.pricelist.getKeyPrices;
@@ -210,4 +209,5 @@ interface Declined {
     disabledItems: string[];
     dupedItems: string[];
     reasonDescription: string;
+    highValue: string[];
 }

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -1206,6 +1206,16 @@ export const optionsSchema: jsonschema.Schema = {
                     required: ['enableCheck', 'minKeys', 'autoDecline'],
                     additionalProperties: false
                 },
+                failedToCheckDuped: {
+                    type: 'object',
+                    properties: {
+                        autoDecline: {
+                            $ref: '#/definitions/only-enable-declineReply'
+                        }
+                    },
+                    required: ['autoDecline'],
+                    additionalProperties: false
+                },
                 escrowCheckFailed: {
                     $ref: '#/definitions/only-ignore-failed'
                 },


### PR DESCRIPTION
- [x] include escrow/banned check failed
- [x] include duped/dupe check failed
- [x] fix bot does not attempt counteroffer on invalid value offer if `manualReview.enable` is set to `false`
- [x] include high value on declined offer summary
- [x] fix high value not shown on the offer review summary (our items)