### PR TITLE
🐛 fix false understocked

### DIFF
--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -1228,11 +1228,8 @@ export default class MyHandler extends Handler {
                         const diff = itemsDiff[sku] as number | null;
 
                         const isBuying = diff > 0; // is buying if true.
-                        const amountCanTrade = this.bot.inventoryManager.amountCanTrade(
-                            sku,
-                            isBuying,
-                            which === 'their'
-                        ); // return a number
+                        const inventoryManager = this.bot.inventoryManager;
+                        const amountCanTrade = inventoryManager.amountCanTrade(sku, isBuying, which === 'their'); // return a number
 
                         if (diff !== 0 && sku !== '5021;6' && amountCanTrade < diff && notIncludeCraftweapons) {
                             if (match.enabled) {
@@ -1267,19 +1264,23 @@ export default class MyHandler extends Handler {
                             amountCanTrade < Math.abs(diff) &&
                             notIncludeCraftweapons
                         ) {
-                            if (match.enabled) {
+                            if (match.enabled && match.min !== 0) {
                                 // User is taking too many
 
-                                wrongAboutOffer.push({
-                                    reason: '🟩_UNDERSTOCKED',
-                                    sku: sku,
-                                    selling: !isBuying,
-                                    diff: diff,
-                                    amountCanTrade: amountCanTrade,
-                                    amountTaking: amount
-                                });
+                                const amountInInventory = inventoryManager.getInventory.getAmount(sku, false);
 
-                                this.bot.listings.checkBySKU(match.sku, null, which === 'their', true);
+                                if (amountInInventory > 0) {
+                                    wrongAboutOffer.push({
+                                        reason: '🟩_UNDERSTOCKED',
+                                        sku: sku,
+                                        selling: !isBuying,
+                                        diff: diff,
+                                        amountCanTrade: amountCanTrade,
+                                        amountTaking: amount
+                                    });
+
+                                    this.bot.listings.checkBySKU(match.sku, null, which === 'their', true);
+                                }
                             } else {
                                 // Item was disabled
                                 wrongAboutOffer.push({
@@ -1432,7 +1433,8 @@ export default class MyHandler extends Handler {
                 // If the diff is greater than 0 then we are buying, less than is selling
                 this.isTradingKeys = true;
                 const isBuying = diff > 0;
-                const amountCanTrade = this.bot.inventoryManager.amountCanTrade('5021;6', isBuying);
+                const inventoryManager = this.bot.inventoryManager;
+                const amountCanTrade = inventoryManager.amountCanTrade('5021;6', isBuying);
 
                 if (diff !== 0 && amountCanTrade < diff) {
                     // User is offering too many
@@ -1449,18 +1451,29 @@ export default class MyHandler extends Handler {
                 }
 
                 const acceptUnderstock = opt.autokeys.accept.understock;
-                if (diff !== 0 && !isBuying && amountCanTrade < Math.abs(diff) && !acceptUnderstock) {
+                if (
+                    diff !== 0 &&
+                    !isBuying &&
+                    amountCanTrade < Math.abs(diff) &&
+                    !acceptUnderstock &&
+                    priceEntry.min !== 0
+                ) {
                     // User is taking too many
-                    wrongAboutOffer.push({
-                        reason: '🟩_UNDERSTOCKED',
-                        sku: '5021;6',
-                        selling: !isBuying,
-                        diff: diff,
-                        amountCanTrade: amountCanTrade,
-                        amountTaking: itemsDict['our']['5021;6']
-                    });
 
-                    this.bot.listings.checkBySKU('5021;6', null, false, true);
+                    const amountInInventory = inventoryManager.getInventory.getAmount('5021;6', false);
+
+                    if (amountInInventory > 0) {
+                        wrongAboutOffer.push({
+                            reason: '🟩_UNDERSTOCKED',
+                            sku: '5021;6',
+                            selling: !isBuying,
+                            diff: diff,
+                            amountCanTrade: amountCanTrade,
+                            amountTaking: itemsDict['our']['5021;6']
+                        });
+
+                        this.bot.listings.checkBySKU('5021;6', null, false, true);
+                    }
                 }
             }
         }


### PR DESCRIPTION
The item exists, but the bot failed to detect it. This should fix it (only on offer received - might still problematic when the trade partner try to use the command to buy stuff from the bot)
![image](https://user-images.githubusercontent.com/47635037/126100412-a4e95bd5-ed3e-408b-8e46-a63918071676.png)
