### PR TITLE
URGENT - 🐛 fix an exploit introduced on v4.4.0/v4.4.1 update

### DIFF
--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -1272,8 +1272,13 @@ export default class MyHandler extends Handler {
                             if (match.enabled) {
                                 // User is taking too many
 
-                                if (match.min !== 0) {
+                                if (
+                                    match.min !== 0 ||
+                                    match.intent === 0 ||
+                                    match.sell?.toValue(keyPrice.metal) === 0 // Just precaution - can't set this if intent was bank
+                                ) {
                                     // If min is set to 0, how come it can be understocked right?
+                                    // fix exploit found on August 4th, 2021
                                     const amountInInventory = inventoryManager.getInventory.getAmount(sku, false);
 
                                     if (amountInInventory > 0) {


### PR DESCRIPTION
A bug that leads to an exploit was introduced on v4.4.0/v4.4.1, where if your bot has any item in the pricelist with:
- an `intent` set to `buy`
- the selling price set to `0` (by default if you set the intent to `buy` and only set the buying price, this will be `0`)

**The bot will accept the trade even if their side is empty.**

Setting intent to `bank` with selling price set to `0` is not possible - except if you manually edit the pricelist.json file, so should not be worry if all your items are set to `bank` with the non-zero selling price.

My test:
![image](https://user-images.githubusercontent.com/47635037/128102707-333bc8ca-c387-4995-8323-498e179b7068.png)
![image](https://user-images.githubusercontent.com/47635037/128102735-b53f6cd5-dcf3-4b30-abec-f2abac3f6087.png)
![image](https://user-images.githubusercontent.com/47635037/128102771-2df02200-8c18-4883-8d4d-5dc24735f212.png)
![image](https://user-images.githubusercontent.com/47635037/128102798-f0eddf11-8b4a-4ad3-9c12-c916a37912ed.png)
![image](https://user-images.githubusercontent.com/47635037/128102818-8288ba47-fc26-43cb-a454-d9cde26174b0.png)
![image](https://user-images.githubusercontent.com/47635037/128102839-7e0ece7c-7df4-4ba9-837f-81f6aefc5d6b.png)
