### PR TITLE
Just decline an offer containing items with wrong intent

### DIFF
--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -1148,7 +1148,7 @@ export default class MyHandler extends Handler {
         let skuToCheck: string[] = [];
         let hasNoPrice = false;
         let hasInvalidItemsOur = false;
-        let hasZeroSellingPriceOur = false;
+
         let isTakingOurItemWithIntentBuy = false;
         let isGivingTheirItemWithIntentSell = false;
 
@@ -1265,13 +1265,8 @@ export default class MyHandler extends Handler {
                             }
                         }
 
-                        const isZeroSellingPrice = match.sell?.toValue(keyPrice.metal) === 0;
-
                         if (which === 'our' && match.intent === 0) {
                             isTakingOurItemWithIntentBuy = true;
-                        } else if (which === 'our' && isZeroSellingPrice) {
-                            // Always check if an offer contains an item with zero selling price on our side
-                            hasZeroSellingPriceOur = true;
                         } else if (which === 'their' && match.intent === 1) {
                             isGivingTheirItemWithIntentSell = true;
                         }
@@ -1427,16 +1422,6 @@ export default class MyHandler extends Handler {
         });
 
         offer.data('prices', itemPrices);
-
-        if (hasZeroSellingPriceOur) {
-            // Always decline an offer containing item(s) with zero selling price on our side
-            offer.log('info', 'is trying to take item(s) with zero selling price, declining...');
-            return {
-                action: 'decline',
-                reason: 'TAKING_ITEMS_WITH_ZERO_SELLING_PRICE',
-                meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
-            };
-        }
 
         if (isTakingOurItemWithIntentBuy) {
             // Always decline an offer taking our item(s) with intent to only buy

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -1149,6 +1149,8 @@ export default class MyHandler extends Handler {
         let hasNoPrice = false;
         let hasInvalidItemsOur = false;
         let hasZeroSellingPriceOur = false;
+        let isTakingOurItemWithIntentBuy = false;
+        let isGivingTheirItemWithIntentSell = false;
 
         const craftAll = this.bot.craftWeapons;
         const uncraftAll = this.bot.uncraftWeapons;
@@ -1264,9 +1266,14 @@ export default class MyHandler extends Handler {
                         }
 
                         const isZeroSellingPrice = match.sell?.toValue(keyPrice.metal) === 0;
-                        if (which === 'our' && isZeroSellingPrice) {
+
+                        if (which === 'our' && match.intent === 0) {
+                            isTakingOurItemWithIntentBuy = true;
+                        } else if (which === 'our' && isZeroSellingPrice) {
                             // Always check if an offer contains an item with zero selling price on our side
                             hasZeroSellingPriceOur = true;
+                        } else if (which === 'their' && match.intent === 1) {
+                            isGivingTheirItemWithIntentSell = true;
                         }
 
                         if (
@@ -1421,6 +1428,36 @@ export default class MyHandler extends Handler {
 
         offer.data('prices', itemPrices);
 
+        if (hasZeroSellingPriceOur) {
+            // Always decline an offer containing item(s) with zero selling price on our side
+            offer.log('info', 'is trying to take item(s) with zero selling price, declining...');
+            return {
+                action: 'decline',
+                reason: 'TAKING_ITEMS_WITH_ZERO_SELLING_PRICE',
+                meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
+            };
+        }
+
+        if (isTakingOurItemWithIntentBuy) {
+            // Always decline an offer taking our item(s) with intent to only buy
+            offer.log('info', 'is trying to take item(s) with intent buy, declining...');
+            return {
+                action: 'decline',
+                reason: 'TAKING_ITEMS_WITH_INTENT_BUY',
+                meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
+            };
+        }
+
+        if (isGivingTheirItemWithIntentSell) {
+            // Always decline an offer giving their item(s) with intent to only sell
+            offer.log('info', 'is trying to give item(s) with intent sell, declining...');
+            return {
+                action: 'decline',
+                reason: 'GIVING_ITEMS_WITH_INTENT_SELL',
+                meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
+            };
+        }
+
         if (exchange.contains.metal && !exchange.contains.keys && !exchange.contains.items) {
             // Offer only contains metal
             offer.log('info', 'only contains metal, declining...');
@@ -1541,16 +1578,6 @@ export default class MyHandler extends Handler {
             return {
                 action: 'decline',
                 reason: 'OVERPAY',
-                meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
-            };
-        }
-
-        if (hasZeroSellingPriceOur) {
-            // Always decline an offer containing item(s) with zero selling price on our side
-            offer.log('info', 'is trying to take item(s) with zero selling price, declining...');
-            return {
-                action: 'decline',
-                reason: 'TAKING_ITEMS_WITH_ZERO_SELLING_PRICE',
                 meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
             };
         }

--- a/src/classes/MyHandler/offer/notify/declined.ts
+++ b/src/classes/MyHandler/offer/notify/declined.ts
@@ -39,11 +39,6 @@ export default function declined(offer: TradeOffer, bot: Bot, isTradingKeys: boo
         const custom = opt.customMessage.decline.crimeAttempt;
         reply = custom ? custom : declined + " because you're attempting to take items for free.";
         //
-    } else if (offerReason.reason === 'TAKING_ITEMS_WITH_ZERO_SELLING_PRICE') {
-        //
-        const custom = opt.customMessage.decline.takingItemsWithZeroSellingPrice;
-        reply = custom ? custom : declined + " because you're attempting to take/buy items without selling price.";
-        //
     } else if (offerReason.reason === 'TAKING_ITEMS_WITH_INTENT_BUY') {
         //
         const custom = opt.customMessage.decline.takingItemsWithIntentBuy;

--- a/src/classes/MyHandler/offer/notify/declined.ts
+++ b/src/classes/MyHandler/offer/notify/declined.ts
@@ -42,7 +42,17 @@ export default function declined(offer: TradeOffer, bot: Bot, isTradingKeys: boo
     } else if (offerReason.reason === 'TAKING_ITEMS_WITH_ZERO_SELLING_PRICE') {
         //
         const custom = opt.customMessage.decline.takingItemsWithZeroSellingPrice;
-        reply = custom ? custom : declined + " because you're attempting to take/buy items without selling price";
+        reply = custom ? custom : declined + " because you're attempting to take/buy items without selling price.";
+        //
+    } else if (offerReason.reason === 'TAKING_ITEMS_WITH_INTENT_BUY') {
+        //
+        const custom = opt.customMessage.decline.takingItemsWithIntentBuy;
+        reply = custom ? custom : declined + " because you're attempting to take items that I only want to buy.";
+        //
+    } else if (offerReason.reason === 'GIVING_ITEMS_WITH_INTENT_SELL') {
+        //
+        const custom = opt.customMessage.decline.givingItemsWithIntentSell;
+        reply = custom ? custom : declined + " because you're attempting to give items that I only want to sell.";
         //
     } else if (offerReason.reason === 'ONLY_METAL') {
         //

--- a/src/classes/MyHandler/offer/processDeclined.ts
+++ b/src/classes/MyHandler/offer/processDeclined.ts
@@ -47,10 +47,6 @@ export default function processDeclined(offer: i.TradeOffer, bot: Bot, isTrading
             case 'CRIME_ATTEMPT':
                 declined.reasonDescription = offerReceived.reason + ': Tried to take our items for free.';
                 break;
-            case 'TAKING_ITEMS_WITH_ZERO_SELLING_PRICE':
-                declined.reasonDescription =
-                    offerReceived.reason + ': Tried to take/buy our item(s) that has no selling price.';
-                break;
             case 'TAKING_ITEMS_WITH_INTENT_BUY':
                 declined.reasonDescription = offerReceived.reason + ': Tried to take/buy our item(s) with intent buy.';
                 break;

--- a/src/classes/MyHandler/offer/processDeclined.ts
+++ b/src/classes/MyHandler/offer/processDeclined.ts
@@ -51,6 +51,12 @@ export default function processDeclined(offer: i.TradeOffer, bot: Bot, isTrading
                 declined.reasonDescription =
                     offerReceived.reason + ': Tried to take/buy our item(s) that has no selling price.';
                 break;
+            case 'TAKING_ITEMS_WITH_INTENT_BUY':
+                declined.reasonDescription = offerReceived.reason + ': Tried to take/buy our item(s) with intent buy.';
+                break;
+            case 'GIVING_ITEMS_WITH_INTENT_SELL':
+                declined.reasonDescription = offerReceived.reason + ': Tried to give their item(s) with intent sell.';
+                break;
             case 'OVERPAY':
                 declined.reasonDescription = offerReceived.reason + ': We are not accepting overpay.';
                 break;

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -526,7 +526,6 @@ export const DEFAULTS: JsonOptions = {
             escrow: '',
             manual: '',
             failedToCounter: '',
-            takingItemsWithZeroSellingPrice: '',
             takingItemsWithIntentBuy: '',
             givingItemsWithIntentSell: ''
         },
@@ -1566,7 +1565,6 @@ interface DeclineNote {
     escrow?: string;
     manual?: string;
     failedToCounter?: string;
-    takingItemsWithZeroSellingPrice?: string;
     takingItemsWithIntentBuy?: string;
     givingItemsWithIntentSell?: string;
 }
@@ -2151,6 +2149,20 @@ function replaceOldProperties(options: Options): boolean {
                 isChanged = true;
             }
         }
+    }
+
+    // v4.4.3/v4.4.4 -> v4.4.5 - Automatically remove takingItemsWithZeroSellingPrice
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    if (options.customMessage?.decline?.takingItemsWithZeroSellingPrice !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //@ts-ignore
+        delete options.customMessage.decline.takingItemsWithZeroSellingPrice;
+
+        options.customMessage.decline['takingItemsWithIntentBuy'] = '';
+        options.customMessage.decline['givingItemsWithIntentSell'] = '';
+
+        isChanged = true;
     }
 
     return isChanged;

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -526,7 +526,9 @@ export const DEFAULTS: JsonOptions = {
             escrow: '',
             manual: '',
             failedToCounter: '',
-            takingItemsWithZeroSellingPrice: ''
+            takingItemsWithZeroSellingPrice: '',
+            takingItemsWithIntentBuy: '',
+            givingItemsWithIntentSell: ''
         },
         accepted: {
             automatic: {
@@ -1565,6 +1567,8 @@ interface DeclineNote {
     manual?: string;
     failedToCounter?: string;
     takingItemsWithZeroSellingPrice?: string;
+    takingItemsWithIntentBuy?: string;
+    givingItemsWithIntentSell?: string;
 }
 
 interface AcceptedNote {

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -1618,9 +1618,6 @@ export const optionsSchema: jsonschema.Schema = {
                         failedToCounter: {
                             type: 'string'
                         },
-                        takingItemsWithZeroSellingPrice: {
-                            type: 'string'
-                        },
                         takingItemsWithIntentBuy: {
                             type: 'string'
                         },
@@ -1643,7 +1640,6 @@ export const optionsSchema: jsonschema.Schema = {
                         'escrow',
                         'manual',
                         'failedToCounter',
-                        'takingItemsWithZeroSellingPrice',
                         'takingItemsWithIntentBuy',
                         'givingItemsWithIntentSell'
                     ],

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -1620,6 +1620,12 @@ export const optionsSchema: jsonschema.Schema = {
                         },
                         takingItemsWithZeroSellingPrice: {
                             type: 'string'
+                        },
+                        takingItemsWithIntentBuy: {
+                            type: 'string'
+                        },
+                        givingItemsWithIntentSell: {
+                            type: 'string'
                         }
                     },
                     required: [
@@ -1637,7 +1643,9 @@ export const optionsSchema: jsonschema.Schema = {
                         'escrow',
                         'manual',
                         'failedToCounter',
-                        'takingItemsWithZeroSellingPrice'
+                        'takingItemsWithZeroSellingPrice',
+                        'takingItemsWithIntentBuy',
+                        'givingItemsWithIntentSell'
                     ],
                     additionalProperties: false
                 },


### PR DESCRIPTION
- The trade partner is trying to buy (to take) items (our items) with the intent set to buy? Declined (they should sell to us, not buy from us).
- The trade partner is trying to sell (to give) items (their items) with the intent set to sell? Declined (they should buy from us, not sell to us).
- This update will also automatically remove the previously added `customMessage.decline.takingItemsWithZeroSellingPrice` property.