### PR TITLE
🐛 fix unable to detect Collector's Chemistry Set

### DIFF
--- a/src/lib/extend/item/getSKU.ts
+++ b/src/lib/extend/item/getSKU.ts
@@ -305,7 +305,7 @@ function getOutput(
         target = schema.getItemByItemName(name).defindex;
         outputQuality = 6;
         outputDefindex = 6522;
-    } else if (output.includes(" Collector's")) {
+    } else if (output.includes("Collector's")) {
         // Collector's Chemistry Set
 
         const name = output.replace("Collector's", '').trim();


### PR DESCRIPTION
The wrong detection causing the bot to think it does not exist or makes the offer put to review:
![image](https://cdn.discordapp.com/attachments/826185684976926761/874645087399845888/Screenshot_20210810-092622_Discord.jpg)
![image](https://user-images.githubusercontent.com/47635037/128963229-898b99dd-7ed2-497b-8509-4851d5144f27.png)

