### PR TITLE
Add resetting item notifications

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -312,6 +312,7 @@ export default class Bot {
         this.addListener(this.client, 'friendMessage', this.onMessage.bind(this), true);
         this.addListener(this.client, 'friendRelationship', this.handler.onFriendRelationship.bind(this.handler), true);
         this.addListener(this.client, 'groupRelationship', this.handler.onGroupRelationship.bind(this.handler), true);
+        this.addListener(this.client, 'newItems', this.onNewItems.bind(this), true);
         this.addListener(this.client, 'webSession', this.onWebSession.bind(this), false);
         this.addListener(this.client, 'steamGuard', this.onSteamGuard.bind(this), false);
         this.addListener(this.client, 'loginKey', this.handler.onLoginKey.bind(this.handler), false);
@@ -873,6 +874,13 @@ export default class Bot {
         }
 
         this.handler.onMessage(steamID, message);
+    }
+
+    private onNewItems(count: number): void {
+        if (count !== 0) {
+            log.debug(`Received ${count} item notifications, resetting to zero`);
+            this.community.resetItemNotifications();
+        }
     }
 
     private onWebSession(sessionID: string, cookies: string[]): void {

--- a/src/types/modules/steam-user/index.d.ts
+++ b/src/types/modules/steam-user/index.d.ts
@@ -16,6 +16,7 @@ declare module 'steam-user' {
         groupRelationship: (groupID: SteamID, relationship: number) => void;
         steamGuard: (domain: string, callback: (authCode: string) => void, lastCodeWrong: boolean) => void;
         loginKey: (loginKey: string) => void;
+        newItems: (count: number) => void;
         error: (err: Error) => void;
     }
 

--- a/src/types/modules/steamcommunity/index.d.ts
+++ b/src/types/modules/steamcommunity/index.d.ts
@@ -66,6 +66,8 @@ declare module 'steamcommunity' {
             callback?: (err?: Error, url?: string) => void
         ): void;
 
+        resetItemNotifications(callback?: (err?: Error) => void): void;
+
         inviteUserToGroup(userID: SteamID | string, groupID: SteamID | string, callback?: (err?: Error) => void): void;
 
         getSteamGroup(id: SteamID | string, callback: (err?: Error, group?: SteamCommunity.Group) => void): void;


### PR DESCRIPTION

Add a listener for the `newItems` event on our `SteamUser` instance. If the number of new items is not zero, the listener `SteamCommunity.resetItemNotifications()` to load our inventory page and reset our item notifications to zero.

Fixes: #871 