### PR TITLE
[fix] Force stop when docker run is enabled

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -35,10 +35,16 @@ const paths = genPaths(options.steamAccountName);
 import log, { init } from './lib/logger';
 init(paths, options);
 
-if (process.env.pm_id === undefined) {
+if (process.env.pm_id === undefined && process.env.DOCKER === undefined) {
     log.warn(
         "You are not running the bot with PM2! If the bot crashes it won't start again." +
             ' Get a VPS and run your bot with PM2: https://github.com/TF2Autobot/tf2autobot/wiki/Getting-a-VPS'
+    );
+}
+
+if (process.env.DOCKER !== undefined) {
+    log.warn(
+        'You are running the bot with Docker! If the bot crashes, it will start again only if you run the container with --restart=always'
     );
 }
 

--- a/src/classes/BotManager.ts
+++ b/src/classes/BotManager.ts
@@ -169,6 +169,13 @@ export default class BotManager {
 
     restartProcess(): Promise<boolean> {
         return new Promise((resolve, reject) => {
+            // When running Docker, just signal the process to kill.
+            // Setting --restart=Always will make sure the container is restarted.
+            if (process.env.DOCKER !== undefined) {
+                this.stop(null);
+                return resolve(true);
+            }
+
             if (process.env.pm_id === undefined) {
                 return resolve(false);
             }


### PR DESCRIPTION
Closes #573

So this is an old issue: bots cannot be restarted via steam command/message if it runs in docker with PM2.

If my logic is not flawed, this should fix the issues by checking if there is a `DOCKER` variable and just terminate the process while doing its cleanup.

The only caveat here is that when running the container, it should contain `--restart=always` and `-e DOCKER=1`

```bash
$ docker run \
    -v $(pwd)/tf2autobot_data/123456:/app/files/123456 \
    -v $(pwd)/tf2autobot_data/ecosystem.json:/app/ecosystem.json \
    --restart=always \
    -e DOCKER=1 \
    tf2autobot/tf2autobot:latest-14.16.0-alpine
```

The change is reverse compatible due to the `DOCKER` variable check.