### PR TITLE
Custom user agent header

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -506,7 +506,10 @@ export default class Bot {
                         this.listingManager = new ListingManager({
                             token: this.options.bptfAccessToken,
                             userID,
-                            userAgent: 'TF2Autobot@' + process.env.BOT_VERSION,
+                            userAgent:
+                                'TF2Autobot' + process.env.USERAGENT_HEADER_CUSTOM !== ''
+                                    ? ` - ${process.env.USERAGENT_HEADER_CUSTOM}`
+                                    : ' - Run your own bot for free',
                             schema: this.schema
                         });
 

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -252,7 +252,7 @@ export default class Commands {
             void this.status.itemStatsCommand(steamID, message);
         } else if (command === 'inventory' && isAdmin) {
             this.status.inventoryCommand(steamID);
-        } else if (command === 'version' && isAdmin) {
+        } else if (command === 'version' && (isAdmin || isWhitelisted)) {
             this.status.versionCommand(steamID);
         } else if (command === 'trades' && isAdmin) {
             this.review.tradesCommand(steamID);

--- a/template.ecosystem.json
+++ b/template.ecosystem.json
@@ -21,6 +21,8 @@
                 "BPTF_ACCESS_TOKEN": "",
                 "BPTF_API_KEY": "",
 
+                "USERAGENT_HEADER_CUSTOM": "",
+
                 "ADMINS": ["<your steamid 64>"],
                 "KEEP": ["<steamid of person to keep in friendslist>"],
                 "ITEM_STATS_WHITELIST": [],

--- a/template.env
+++ b/template.env
@@ -8,6 +8,8 @@ STEAM_IDENTITY_SECRET=""
 BPTF_ACCESS_TOKEN=""
 BPTF_API_KEY=""
 
+USERAGENT_HEADER_CUSTOM=""
+
 ADMINS=["<your steamid 64>"]
 KEEP=["<steamid of person to keep in friendslist>"]
 ITEM_STATS_WHITELIST=[]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/47635037/166475209-f93db7cf-0323-4808-84d8-e8d04f9932d1.png)

😂
![image](https://user-images.githubusercontent.com/47635037/166475587-1bf114bb-09b5-494d-9894-a0469391eeba.png)

Note:
- This will only affect requests that the bot will send to the backpack.tf through [@TF2Autobot/bptf-listings](https://github.com/TF2Autobot/node-bptf-listings) only. All other web/API requests outside that module will still send the bot version.
- The default is "TF2Autobot - Run your own bot for free" (credit: @Nicklason), and if you fill in the `USERAGENT_HEADER_CUSTOM` value, it will be "TF2Autobot - \<Whatever you put it there\>".
- I don't know if there's any character limit, but **please use it wisely, and at your own risk!**