### PR TITLE
🐛 fix ENABLE_SOCKET not properly done its job

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -613,11 +613,6 @@ export default class Bot {
                         );
                     },
                     (callback: (err?) => void): void => {
-                        if (this.options.enableSocket === false) {
-                            log.warn('Disabling socket...');
-                            this.priceSource.shutdown();
-                        }
-
                         log.info('Setting up pricelist...');
 
                         const pricelist = Array.isArray(data.pricelist)

--- a/src/classes/BotManager.ts
+++ b/src/classes/BotManager.ts
@@ -70,7 +70,7 @@ export default class BotManager {
                     },
                     (callback): void => {
                         log.info('Starting bot...');
-                        this.pricer.init();
+                        this.pricer.init(options.enableSocket);
                         this.bot = new Bot(this, options, this.pricer);
 
                         void this.bot.start().asCallback(callback);
@@ -94,10 +94,7 @@ export default class BotManager {
                         return this.stop(null, false, false);
                     }
 
-                    if (this.bot?.options.enableSocket) {
-                        log.info('Connecting to socket server...');
-                        this.pricer.connect();
-                    }
+                    this.pricer.connect(this.bot?.options.enableSocket);
 
                     this.schemaManager = this.bot.schemaManager;
 
@@ -212,7 +209,7 @@ export default class BotManager {
         }
 
         // Disconnect from socket server to stop price updates
-        this.pricer.shutdown();
+        this.pricer.shutdown(this.bot?.options.enableSocket);
     }
 
     private exit(err: Error | null): void {

--- a/src/classes/IPricer.ts
+++ b/src/classes/IPricer.ts
@@ -23,11 +23,11 @@ export default interface IPricer {
 
     get isPricerConnecting(): boolean;
 
-    connect(): void;
+    connect(enabled: boolean): void;
 
-    shutdown(): void;
+    shutdown(enabled: boolean): void;
 
-    init(): void;
+    init(enabled: boolean): void;
 
     bindHandlePriceEvent(onPriceChange: (item: GetItemPriceResponse) => void): void;
 }

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -237,7 +237,9 @@ export default class Pricelist extends EventEmitter {
     }
 
     init(): void {
-        this.priceSource.bindHandlePriceEvent(this.boundHandlePriceChange);
+        if (this.options.enableSocket) {
+            this.priceSource.bindHandlePriceEvent(this.boundHandlePriceChange);
+        }
     }
 
     hasPrice(sku: string, onlyEnabled = false): boolean {

--- a/src/lib/pricer/custom/custom-pricer.ts
+++ b/src/lib/pricer/custom/custom-pricer.ts
@@ -71,20 +71,26 @@ export default class CustomPricer implements IPricer {
         return this.api.getOptions();
     }
 
-    shutdown(): void {
-        this.socketManager.shutDown();
+    shutdown(enabled: boolean): void {
+        if (enabled) {
+            this.socketManager.shutDown();
+        }
     }
 
     get isPricerConnecting(): boolean {
         return this.socketManager.isConnecting;
     }
 
-    connect(): void {
-        this.socketManager.connect();
+    connect(enabled: boolean): void {
+        if (enabled) {
+            this.socketManager.connect();
+        }
     }
 
-    init(): void {
-        return this.socketManager.init();
+    init(enabled: boolean): void {
+        if (enabled) {
+            this.socketManager.init();
+        }
     }
 
     bindHandlePriceEvent(onPriceChange: (item: GetItemPriceResponse) => void): void {

--- a/src/lib/pricer/pricestf/prices-tf-pricer.ts
+++ b/src/lib/pricer/pricestf/prices-tf-pricer.ts
@@ -79,20 +79,26 @@ export default class PricesTfPricer implements IPricer {
         }
     }
 
-    shutdown(): void {
-        this.socketManager.shutDown();
+    shutdown(enabled: boolean): void {
+        if (enabled) {
+            this.socketManager.shutDown();
+        }
     }
 
     get isPricerConnecting(): boolean {
         return this.socketManager.isConnecting;
     }
 
-    connect(): void {
-        this.socketManager.connect();
+    connect(enabled: boolean): void {
+        if (enabled) {
+            this.socketManager.connect();
+        }
     }
 
-    init(): void {
-        return this.socketManager.init();
+    init(enabled: boolean): void {
+        if (enabled) {
+            this.socketManager.init();
+        }
     }
 
     parsePricesTfMessageEvent(raw: string): PricesTfItemMessageEvent {


### PR DESCRIPTION
Credit @EliteOneTube:
![image](https://user-images.githubusercontent.com/47635037/170525756-e8d859d1-9af6-4274-987c-2579a1f31329.png)

The error in question which crashes the bot was: `WebSocket was closed before the connection was established`, which should be fixed on the 1f66f50 commit.

Before this commit, the bot still initialize the `socketManager`, and added the `error` eventListener, which then if `enableSocket` is set to `false`, the `shutDown` is called, but `ws` don't have `removeAllEventListener` method, so that the `error` event never get deleted, thus when `error` event is emitted, the bot tries to reconnect while the websocket is in the `CONNECTING` state which results in crashing the bot despite having the enableSocket option disabled.