### PR TITLE
🔥 Remove allow banned, option to set Rep.tf as primary source

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -180,12 +180,15 @@ export default class Bot {
     }
 
     checkBanned(steamID: SteamID | string): Promise<IsBanned> {
-        if (this.options.bypass.bannedPeople.allow) {
-            return Promise.resolve({ isBanned: false });
-        }
-
         return Promise.resolve(
-            isBanned(steamID, this.options.bptfAPIKey, this.userID, this.options.bypass.bannedPeople.checkMptfBanned)
+            isBanned(
+                steamID,
+                this.options.bptfApiKey,
+                this.options.mptfApiKey,
+                this.userID,
+                this.options.miscSettings.reputationCheck.checkMptfBanned,
+                this.options.miscSettings.reputationCheck.reptfAsPrimarySource
+            )
         );
     }
 
@@ -487,7 +490,7 @@ export default class Bot {
                         });
                     },
                     (callback): void => {
-                        if (this.options.bptfAPIKey && this.options.bptfAccessToken) {
+                        if (this.options.bptfApiKey && this.options.bptfAccessToken) {
                             /* eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
                             return callback(null);
                         }
@@ -797,7 +800,7 @@ export default class Bot {
             return Promise.all([this.getOrCreateBptfAPIKey, this.getBptfAccessToken]).then(([apiKey, accessToken]) => {
                 log.verbose('Got backpack.tf API key and access token!');
 
-                this.options.bptfAPIKey = apiKey;
+                this.options.bptfApiKey = apiKey;
                 this.options.bptfAccessToken = accessToken;
                 this.handler.onBptfAuth({ apiKey, accessToken });
 

--- a/src/classes/Carts/CartQueue.ts
+++ b/src/classes/Carts/CartQueue.ts
@@ -67,7 +67,7 @@ export default class CartQueue {
             // determine whether it's good time to restart or not
             try {
                 // test if backpack.tf is alive by performing bptf banned check request
-                await isBptfBanned(steamID, this.bot.options.bptfAPIKey, this.bot.userID);
+                await isBptfBanned(steamID, this.bot.options.bptfApiKey, this.bot.userID);
             } catch (err) {
                 // do not restart, try again after 3 minutes
                 clearTimeout(this.queuePositionCheck);

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -2530,7 +2530,7 @@ export default class MyHandler extends Handler {
                     Cookie: 'user-id=' + this.bot.userID
                 },
                 params: {
-                    key: this.opt.bptfAPIKey,
+                    key: this.opt.bptfApiKey,
                     steamids: steamID64
                 }
             })

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -2374,22 +2374,7 @@ export default class MyHandler extends Handler {
             .checkBanned(steamID)
             .then(banned => {
                 if (banned.isBanned) {
-                    let checkResult = '';
-                    if (banned.contents) {
-                        checkResult = 'Check results:\n';
-                        Object.keys(banned.contents).forEach((website, index) => {
-                            if (banned.contents[website] !== 'clean') {
-                                if (index > 0) {
-                                    checkResult += '\n';
-                                }
-                                checkResult += `(${index + 1}) ${website}: ${banned.contents[website]}`;
-                            }
-                        });
-                    }
-
-                    log.info(
-                        `Declining friend request and blocking ${steamID64}${checkResult ? ', ' + checkResult : '...'}`
-                    );
+                    log.info(`Declining friend request and blocking ${steamID64}...`);
 
                     this.bot.client.removeFriend(steamID);
                     this.bot.client.blockUser(steamID, err => {

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -2369,6 +2369,20 @@ export default class MyHandler extends Handler {
         }
 
         const steamID64 = typeof steamID === 'string' ? steamID : steamID.getSteamID64();
+        const accept = () => {
+            log.info(`Accepting friend request from ${steamID64}...`);
+            this.bot.client.addFriend(steamID, err => {
+                if (err) {
+                    log.warn(`Failed to accept friend request from ${steamID64}: `, err);
+                    return;
+                }
+                log.debug('Friend request has been accepted');
+            });
+        };
+
+        if (this.bot.isAdmin(steamID)) {
+            return accept();
+        }
 
         void this.bot
             .checkBanned(steamID)
@@ -2386,14 +2400,7 @@ export default class MyHandler extends Handler {
                     return;
                 }
 
-                log.info(`Accepting friend request from ${steamID64}...`);
-                this.bot.client.addFriend(steamID, err => {
-                    if (err) {
-                        log.warn(`Failed to accept friend request from ${steamID64}: `, err);
-                        return;
-                    }
-                    log.debug('Friend request has been accepted');
-                });
+                return accept();
             })
             .catch(err => {
                 log.error('Failed to check banned on respondToFriendRequest: ', err);

--- a/src/classes/MyHandler/offer/review/send-review.ts
+++ b/src/classes/MyHandler/offer/review/send-review.ts
@@ -45,8 +45,8 @@ export default async function sendReview(
                 const custom = opt.manualReview.bannedCheckFailed.note;
                 reply = custom
                     ? custom
-                    : 'Backpack.tf or steamrep.com is down and I failed to check your backpack.tf/steamrep' +
-                      ' status, please wait for my owner to manually accept/decline your offer.';
+                    : 'I have failed to obtain data about your reputation status' +
+                      ', please wait for my owner to manually accept/decline your offer.';
             } else if (reasons.includes('⬜_ESCROW_CHECK_FAILED')) {
                 const custom = opt.manualReview.escrowCheckFailed.note;
                 reply = custom
@@ -171,7 +171,7 @@ export async function sendToAdmin(
         } from ${offer.partner.toString()} is pending review.` +
         `\nReasons: ${reasons}` +
         (reasons.includes('⬜_BANNED_CHECK_FAILED')
-            ? '\n\nBackpack.tf or steamrep.com are down, please manually check if this person is banned before accepting the offer.'
+            ? '\n\nFailed to get reputation status, please manually check if this person is banned before accepting the offer.'
             : reasons.includes('⬜_ESCROW_CHECK_FAILED')
             ? '\n\nSteam is down, please manually check if this person has escrow (trade holds) enabled.'
             : reasons.includes('⬜_HALTED')

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -53,6 +53,10 @@ export const DEFAULTS: JsonOptions = {
         },
         deleteUntradableJunk: {
             enable: false
+        },
+        reputationCheck: {
+            checkMptfBanned: true,
+            reptfAsPrimarySource: true
         }
     },
 
@@ -120,10 +124,6 @@ export const DEFAULTS: JsonOptions = {
         },
         giftWithoutMessage: {
             allow: false
-        },
-        bannedPeople: {
-            allow: false,
-            checkMptfBanned: true
         }
     },
 
@@ -1133,6 +1133,12 @@ interface MiscSettings {
     game?: Game;
     alwaysRemoveItemAttributes?: AlwaysRemoveItemAttributes;
     deleteUntradableJunk?: OnlyEnable;
+    reputationCheck: ReputationCheck;
+}
+
+interface ReputationCheck {
+    checkMptfBanned: boolean;
+    reptfAsPrimarySource: boolean;
 }
 
 interface AlwaysRemoveItemAttributes {
@@ -1203,15 +1209,10 @@ interface Bypass {
     escrow?: OnlyAllow;
     overpay?: OnlyAllow;
     giftWithoutMessage?: OnlyAllow;
-    bannedPeople?: BannedPeople;
 }
 
 interface OnlyAllow {
     allow?: boolean;
-}
-
-interface BannedPeople extends OnlyAllow {
-    checkMptfBanned: boolean;
 }
 
 // ------------ TradeSummary ------------
@@ -2002,9 +2003,10 @@ export default interface Options extends JsonOptions {
     steamIdentitySecret?: string;
 
     bptfAccessToken?: string;
-    bptfAPIKey?: string;
-
+    bptfApiKey?: string;
     useragentHeaderCustom?: string;
+
+    mptfApiKey?: string;
 
     admins?: string[];
     keep?: string[];
@@ -2237,6 +2239,30 @@ function replaceOldProperties(options: Options): boolean {
         isChanged = true;
     }
 
+    // v4.12.1 -> v4.13.0
+    /*eslint-disable */
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    if (options.bypass.bannedPeople !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //@ts-ignore
+        const mptfCheckValue = options.bypass.bannedPeople?.mptfCheck;
+
+        if (typeof mptfCheckValue === 'boolean') {
+            if (options.miscSettings.reputationCheck !== undefined) {
+                options.miscSettings.reputationCheck.checkMptfBanned = mptfCheckValue;
+            } else {
+                options.miscSettings['reputationCheck'] = {
+                    checkMptfBanned: mptfCheckValue,
+                    reptfAsPrimarySource: true
+                };
+            }
+
+            isChanged = true;
+        }
+    }
+    /*eslint-enable */
+
     return isChanged;
 }
 
@@ -2256,9 +2282,10 @@ export function loadOptions(options?: Options): Options {
         steamIdentitySecret: getOption('steamIdentitySecret', '', String, incomingOptions),
 
         bptfAccessToken: getOption('bptfAccessToken', '', String, incomingOptions),
-        bptfAPIKey: getOption('bptfAPIKey', '', String, incomingOptions),
-
+        bptfApiKey: getOption('bptfApiKey', '', String, incomingOptions),
         useragentHeaderCustom: getOption('useragentHeaderCustom', '', String, incomingOptions),
+
+        mptfApiKey: getOption('mptfApiKey', '', String, incomingOptions),
 
         admins: getOption('admins', [], jsonParseArray, incomingOptions),
         keep: getOption('keep', [], jsonParseArray, incomingOptions),

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -1454,7 +1454,7 @@ export default class Trades {
             // determine whether it's good time to restart or not
             try {
                 // test if backpack.tf is alive by performing bptf banned check request
-                await isBptfBanned(steamID, this.bot.options.bptfAPIKey, this.bot.userID);
+                await isBptfBanned(steamID, this.bot.options.bptfApiKey, this.bot.userID);
             } catch (err) {
                 // do not restart, try again after 3 minutes
                 clearTimeout(this.restartOnEscrowCheckFailed);

--- a/src/lib/DiscordWebhook/sendOfferReview.ts
+++ b/src/lib/DiscordWebhook/sendOfferReview.ts
@@ -123,6 +123,8 @@ export default function sendOfferReview(
                             ? '\n\n`Failed to get reputation status, please manually check if this person is banned before accepting the offer.`'
                             : reasons.includes('⬜_ESCROW_CHECK_FAILED')
                             ? '\n\n`Steam down, please manually check if this person have escrow.`'
+                            : reasons.includes('⬜_HALTED')
+                            ? '\n\n`Offer received during halt mode`'
                             : '') +
                         summary +
                         (message.length !== 0 ? `\n\n💬 Offer message: "${message}"` : '') +

--- a/src/lib/DiscordWebhook/sendOfferReview.ts
+++ b/src/lib/DiscordWebhook/sendOfferReview.ts
@@ -120,7 +120,7 @@ export default function sendOfferReview(
                     description:
                         `⚠️ An offer sent by ${partnerNameNoFormat} is waiting for review.\nReasons: ${reasons}` +
                         (reasons.includes('⬜_BANNED_CHECK_FAILED')
-                            ? '\n\n`Backpack.tf or steamrep.com down, please manually check if this person is banned before accepting the offer.`'
+                            ? '\n\n`Failed to get reputation status, please manually check if this person is banned before accepting the offer.`'
                             : reasons.includes('⬜_ESCROW_CHECK_FAILED')
                             ? '\n\n`Steam down, please manually check if this person have escrow.`'
                             : '') +

--- a/src/lib/bans.ts
+++ b/src/lib/bans.ts
@@ -200,6 +200,10 @@ function isMptfBanned(steamID: SteamID | string, mptfApiKey: string, checkMptfBa
             return resolve(false);
         }
 
+        if (mptfApiKey === '') {
+            return reject(new Error('Marketplace.tf API key was not set.'));
+        }
+
         void axios({
             url: 'https://api.backpack.tf/api/users/info/v1',
             headers: {

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -430,6 +430,19 @@ export const optionsSchema: jsonschema.Schema = {
                 },
                 deleteUntradableJunk: {
                     $ref: '#/definitions/only-enable'
+                },
+                reputationCheck: {
+                    type: 'object',
+                    properties: {
+                        checkMptfBanned: {
+                            type: 'boolean'
+                        },
+                        reptfAsPrimarySource: {
+                            type: 'boolean'
+                        }
+                    },
+                    required: ['checkMptfBanned', 'reptfAsPrimarySource'],
+                    additionalProperties: false
                 }
             },
             required: [
@@ -623,22 +636,9 @@ export const optionsSchema: jsonschema.Schema = {
                 },
                 giftWithoutMessage: {
                     $ref: '#/definitions/only-allow'
-                },
-                bannedPeople: {
-                    type: 'object',
-                    properties: {
-                        allow: {
-                            type: 'boolean'
-                        },
-                        checkMptfBanned: {
-                            type: 'boolean'
-                        }
-                    },
-                    required: ['allow', 'checkMptfBanned'],
-                    additionalProperties: false
                 }
             },
-            required: ['escrow', 'overpay', 'giftWithoutMessage', 'bannedPeople'],
+            required: ['escrow', 'overpay', 'giftWithoutMessage'],
             additionalProperties: false
         },
         tradeSummary: {

--- a/template.ecosystem.json
+++ b/template.ecosystem.json
@@ -23,6 +23,8 @@
 
                 "USERAGENT_HEADER_CUSTOM": "",
 
+                "MPTF_API_KEY": "",
+
                 "ADMINS": ["<your steamid 64>"],
                 "KEEP": ["<steamid of person to keep in friendslist>"],
                 "ITEM_STATS_WHITELIST": [],

--- a/template.env
+++ b/template.env
@@ -10,6 +10,8 @@ BPTF_API_KEY=""
 
 USERAGENT_HEADER_CUSTOM=""
 
+MPTF_API_KEY=""
+
 ADMINS=["<your steamid 64>"]
 KEEP=["<steamid of person to keep in friendslist>"]
 ITEM_STATS_WHITELIST=[]


### PR DESCRIPTION
## Changes
- `bypass.bannedPeople.allow` no longer available.
- `bypass.bannedPeople` now changed to `miscSettings.reputationCheck`.

## New
- `miscSettings.reputationCheck.reptfAsPrimarySource` (default is `true`)
   - When this is set to `false`:
      - The bot will get data from individual sites - Backpack.tf, Steamrep.com[, and Marketplace.tf]
      - If you set `miscSettings.reputationCheck.checkMptfBanned` to `true`:
         - If you're able to obtain the API key from Marketplace.tf, please make sure to fill in the `MPTF_API_KEY` in your `.env` or `ecosystem.json` file.
         - Otherwise, the bot will try to get data from `rep.tf`.
   - Else, if this setting is set to `true`:
      - The bot will first try to gather all data from `rep.tf`, if failed, then it will try to get data from individual sites.
