### PR TITLE
✨ `!withdrawMptf` command

### DIFF
--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -735,11 +735,16 @@ export default class Commands {
 
                     if (err) {
                         log.warn('Error while trying to cancel an offer: ', err);
-                        this.bot.sendMessage(
+                        return this.bot.sendMessage(
                             steamID,
                             `❌ Ohh nooooes! Something went wrong while trying to cancel the offer: ${err.message}`
                         );
                     }
+
+                    return this.bot.sendMessage(
+                        steamID,
+                        `✅ Offer sent (${offer.id}) has been successfully cancelled.`
+                    );
                 });
             });
         }

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -1035,7 +1035,7 @@ export default class Commands {
         }
 
         try {
-            const mptfItemsSkus = await getMptfDashboardItems(this.bot.options.mptfApiKey);
+            const mptfItemsSkus = await getMptfDashboardItems(this.bot.options.mptfApiKey, params.ignorepainted);
             const dict = this.bot.inventoryManager.getInventory.getItems;
             const clonedDict = Object.assign({}, dict);
 
@@ -1300,7 +1300,40 @@ export default class Commands {
     }
 }
 
-function getMptfDashboardItems(mptfApiKey: string): Promise<GetMptfDashboardItemsReturn> {
+const paintCanDefindexes = [
+    5023, // Paint Can
+    5027, // Indubitably Green
+    5028, // Zepheniah's Greed
+    5029, // Noble Hatter's Violet
+    5030, // Color No. 216-190-216
+    5031, // A Deep Commitment to Purple
+    5032, // Mann Co. Orange
+    5033, // Muskelmannbraun
+    5034, // Peculiarly Drab Tincture
+    5035, // Radigan Conagher Brown
+    5036, // Ye Olde Rustic Colour
+    5037, // Australium Gold
+    5038, // Aged Moustache Grey
+    5039, // An Extraordinary Abundance of Tinge
+    5040, // A Distinctive Lack of Hue
+    5046, // Team Spirit
+    5051, // Pink as Hell
+    5052, // A Color Similar to Slate
+    5053, // Drably Olive
+    5054, // The Bitter Taste of Defeat and Lime
+    5055, // The Color of a Gentlemann's Business Pants
+    5056, // Dark Salmon Injustice
+    5060, // Operator's Overalls
+    5061, // Waterlogged Lab Coat
+    5062, // Balaclavas Are Forever
+    5063, // An Air of Debonair
+    5064, // The Value of Teamwork
+    5065, // Cream Spirit
+    5076, // A Mann's Mint
+    5077 // After Eight
+];
+
+function getMptfDashboardItems(mptfApiKey: string, ignorePainted = false): Promise<GetMptfDashboardItemsReturn> {
     return new Promise((resolve, reject) => {
         void axios({
             method: 'GET',
@@ -1321,11 +1354,16 @@ function getMptfDashboardItems(mptfApiKey: string): Promise<GetMptfDashboardItem
 
                 const items = body.items
                     .map(item => {
+                        let sku = item.sku
+                            .replace(/;ks-\d+/, '') // Sheen
+                            .replace(/;ke-\d+/, ''); // Killstreaker
+
+                        if (ignorePainted || paintCanDefindexes.includes(item.defindex)) {
+                            sku = sku.replace(/;[p][0-9]+/, ''); // Painted
+                        }
+
                         return {
-                            sku: item.sku
-                                .replace(/;ks-\d+/, '') // Sheen
-                                .replace(/;ke-\d+/, '') // Killstreaker
-                                .replace(/;[p][0-9]+/, ''), // Painted
+                            sku,
                             amount: item.num_for_sale
                         };
                     })

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -1047,7 +1047,7 @@ export default class Commands {
                     delete clonedDict[sku];
                 }
 
-                if (mptfItemsSkus[sku] && mptfItemsSkus[sku] + clonedDict[sku].length > params.max) {
+                if (mptfItemsSkus[sku] && mptfItemsSkus[sku] + (clonedDict[sku] ?? []).length > params.max) {
                     // If this particular item already exist on mptf
                     // and amount on mptf + amount that bot has more than max, ignore
                     delete clonedDict[sku];
@@ -1063,9 +1063,16 @@ export default class Commands {
                     this.weaponsAsCurrency.enable && this.weaponsAsCurrency.withUncraft ? this.bot.uncraftWeapons : []
                 );
 
-            Object.keys(clonedDict).forEach(sku => {
-                cart.addOurItem(sku, Math.min(clonedDict[sku].length, params.max));
-            });
+            for (const sku in clonedDict) {
+                if (!Object.prototype.hasOwnProperty.call(clonedDict, sku)) {
+                    continue;
+                }
+
+                if (Array.isArray(clonedDict[sku])) {
+                    cart.addOurItem(sku, Math.min(clonedDict[sku].length, params.max));
+                }
+            }
+
             Cart.addCart(cart);
             this.addCartToQueue(cart, false, false);
         } catch (err) {

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -1288,6 +1288,9 @@ function getMptfDashboardItems(mptfApiKey: string): Promise<GetMptfDashboardItem
         void axios({
             method: 'GET',
             url: 'https://marketplace.tf/api/Seller/GetDashboardItems/v2',
+            headers: {
+                'User-Agent': 'TF2Autobot@' + process.env.BOT_VERSION
+            },
             params: {
                 key: mptfApiKey
             }

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -1020,7 +1020,6 @@ export default class Commands {
         }
 
         const params = CommandParser.parseParams(CommandParser.removeCommand(removeLinkProtocol(message)));
-        // limit
 
         if (params.max === undefined) {
             params.max = 1;

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -204,7 +204,7 @@ export default class Commands {
             void this.depositCommand(steamID, message);
         } else if (['withdraw', 'w'].includes(command) && isAdmin) {
             this.withdrawCommand(steamID, message);
-        } else if ('withdrawmptf' && isAdmin) {
+        } else if (command === 'withdrawmptf' && isAdmin) {
             void this.withdrawMptfCommand(steamID, message);
         } else if (command === 'add' && isAdmin) {
             await this.pManager.addCommand(steamID, message);

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -1030,6 +1030,10 @@ export default class Commands {
             params.max = 1;
         }
 
+        if (params.ignorepainted === undefined) {
+            params.ignorepainted = false;
+        }
+
         try {
             const mptfItemsSkus = await getMptfDashboardItems(this.bot.options.mptfApiKey);
             const dict = this.bot.inventoryManager.getInventory.getItems;
@@ -1049,6 +1053,12 @@ export default class Commands {
                 }
 
                 if (pureAndWeapons.includes(sku)) {
+                    delete clonedDict[sku];
+                    continue;
+                }
+
+                // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+                if (params.ignorepainted && sku.match(/;[p][0-9]+/) !== null) {
                     delete clonedDict[sku];
                     continue;
                 }

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -1047,12 +1047,10 @@ export default class Commands {
                     delete clonedDict[sku];
                 }
 
-                if (mptfItemsSkus[sku]) {
+                if (mptfItemsSkus[sku] && mptfItemsSkus[sku] + clonedDict[sku].length > params.max) {
                     // If this particular item already exist on mptf
-                    if (mptfItemsSkus[sku] + clonedDict[sku].length > params.max) {
-                        // If amount on mptf + amount that bot has more than max, ignore
-                        delete clonedDict[sku];
-                    }
+                    // and amount on mptf + amount that bot has more than max, ignore
+                    delete clonedDict[sku];
                 }
             }
 

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -1063,9 +1063,8 @@ export default class Commands {
                     continue;
                 }
 
-                if (mptfItemsSkus[sku] && mptfItemsSkus[sku] + clonedDict[sku].length > params.max) {
-                    // If this particular item already exist on mptf
-                    // and amount on mptf + amount that bot has more than max, ignore
+                if (mptfItemsSkus[sku] && mptfItemsSkus[sku] >= params.max) {
+                    // If this particular item already exist on mptf and it's more than or equal to max, ignore
                     delete clonedDict[sku];
                 }
             }
@@ -1084,7 +1083,11 @@ export default class Commands {
                     continue;
                 }
 
-                cart.addOurItem(sku, Math.min(clonedDict[sku].length, params.max));
+                const amountInInventory = clonedDict[sku].length;
+                cart.addOurItem(
+                    sku,
+                    amountInInventory >= params.max ? params.max - (mptfItemsSkus[sku] ?? 0) : amountInInventory
+                );
             }
 
             Cart.addCart(cart);

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -1043,7 +1043,9 @@ export default class Commands {
 
             const pureAndWeapons = weaponsAsCurrency.enable
                 ? ['5021;6', '5000;6', '5001;6', '5002;6'].concat(
-                      weaponsAsCurrency.withUncraft ? this.bot.craftWeapons.concat(this.bot.uncraftWeapons) : []
+                      weaponsAsCurrency.withUncraft
+                          ? this.bot.craftWeapons.concat(this.bot.uncraftWeapons)
+                          : this.bot.craftWeapons
                   )
                 : ['5021;6', '5000;6', '5001;6', '5002;6'];
 

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -1050,9 +1050,10 @@ export default class Commands {
 
                 if (pureAndWeapons.includes(sku)) {
                     delete clonedDict[sku];
+                    continue;
                 }
 
-                if (mptfItemsSkus[sku] && mptfItemsSkus[sku] + (clonedDict[sku] ?? []).length > params.max) {
+                if (mptfItemsSkus[sku] && mptfItemsSkus[sku] + clonedDict[sku].length > params.max) {
                     // If this particular item already exist on mptf
                     // and amount on mptf + amount that bot has more than max, ignore
                     delete clonedDict[sku];
@@ -1073,9 +1074,7 @@ export default class Commands {
                     continue;
                 }
 
-                if (Array.isArray(clonedDict[sku])) {
-                    cart.addOurItem(sku, Math.min(clonedDict[sku].length, params.max));
-                }
+                cart.addOurItem(sku, Math.min(clonedDict[sku].length, params.max));
             }
 
             Cart.addCart(cart);

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -1076,10 +1076,8 @@ export default class Commands {
             Cart.addCart(cart);
             this.addCartToQueue(cart, false, false);
         } catch (err) {
-            return this.bot.sendMessage(
-                steamID,
-                `❌ Error getting Marketplace.tf Dashboard Item: ${JSON.stringify(err)}`
-            );
+            log.error('Error on !withdrawMptf:', err);
+            return this.bot.sendMessage(steamID, `❌ Error: ${(err as Error)?.message}`);
         }
     }
 

--- a/src/classes/Commands/sub-classes/Help.ts
+++ b/src/classes/Commands/sub-classes/Help.ts
@@ -78,6 +78,7 @@ export default class HelpCommands {
                     [
                         '!deposit (sku|name|defindex)=<a>&amount=<number> - Deposit items',
                         '!withdraw (sku|name|defindex)=<a>&amount=<number> - Withdraw items',
+                        '!withdrawMptf [max=<number>] - [Exclusive Marketplace.tf Sellers] Withdraw items that does not exist on Marketplace.tf Dashboard items',
                         "!expand craftable=(true|false) - Use Backpack Expanders to increase the bot's inventory limit",
                         '!use (sku|assetid)=<a> - Use an item (such as Gift-Stuffed Stocking 2020 - sku: 5923;6;untradable)',
                         "!delete (sku|assetid)=<a> - Delete an item from the bot's inventory (SKU input only) 🚮",

--- a/src/lib/bans.ts
+++ b/src/lib/bans.ts
@@ -206,7 +206,11 @@ function isSteamRepMarked(steamID: SteamID | string): Promise<SiteResult> {
     });
 }
 
-function isMptfBanned(steamID: SteamID | string, mptfApiKey: string, checkMptfBanned: boolean): Promise<SiteResult> {
+export function isMptfBanned(
+    steamID: SteamID | string,
+    mptfApiKey: string,
+    checkMptfBanned: boolean
+): Promise<SiteResult> {
     const steamID64 = steamID.toString();
 
     return new Promise((resolve, reject) => {

--- a/src/lib/bans.ts
+++ b/src/lib/bans.ts
@@ -206,11 +206,7 @@ function isSteamRepMarked(steamID: SteamID | string): Promise<SiteResult> {
     });
 }
 
-export function isMptfBanned(
-    steamID: SteamID | string,
-    mptfApiKey: string,
-    checkMptfBanned: boolean
-): Promise<SiteResult> {
+function isMptfBanned(steamID: SteamID | string, mptfApiKey: string, checkMptfBanned: boolean): Promise<SiteResult> {
     const steamID64 = steamID.toString();
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
**[Exclusive Marketplace.tf Sellers]**
Withdraw items that does not exist in your Marketplace.tf Dashboard items.

Parameter:
- `max` (optional): default is 1. If the amount of item x in your Marketplace.tf dashboard + your bot inventory > max, then the item will remain untouched.
- `ignorepainted` (optional): default is `false`. If set to true, your bot will not send any painted items (only if your `normalize` and `highValue.painted` settings are correct).
- `withgroup` (optional): no default value. If you want to withdraw only a certain group in your pricelist, then use this.

Usage example:
- `!withdrawMptf` (max will be 1, ignorepainted will be false)
- `!withdrawMptf max=3`
- `!withdrawMptf ignorepainted=true`
- `!withdrawMptf max=2&ignorepainted=true`
- `!withdrawMptf withgroup=mptf`
- `!withdrawMptf withgroup=mptf&max=50`

Requirement: The `MPTF_API_KEY` must be filled with your own (main) Marketplace.tf API key.

TODO:
- [x] Test