### PR TITLE
✨ Improvement on the `!block` command

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -68,6 +68,13 @@ ON_DEATH({ uncaughtException: true })((signalOrErr, origin) => {
     if (crashed) {
         const botReady = botManager.isBotReady;
 
+        const stackTrace = inspect.inspect(origin);
+
+        if (stackTrace.includes('Error: Not allowed')) {
+            log.error('Not Allowed');
+            return botManager.stop(null, true, true);
+        }
+
         const errorMessage = [
             'TF2Autobot' +
                 (!botReady
@@ -77,7 +84,7 @@ ON_DEATH({ uncaughtException: true })((signalOrErr, origin) => {
                 process.arch
             }}`,
             'Stack trace:',
-            inspect.inspect(origin),
+            stackTrace,
             `${uptime()}`
         ].join('\r\n');
 

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -33,6 +33,7 @@ import { sendStats } from '../lib/DiscordWebhook/export';
 import Options from './Options';
 import IPricer from './IPricer';
 import { EventEmitter } from 'events';
+import { Blocked } from './MyHandler/interfaces';
 
 export default class Bot {
     // Modules and classes
@@ -107,6 +108,8 @@ export default class Bot {
     private loginAttempts: Dayjs[] = [];
 
     private admins: SteamID[] = [];
+
+    public blockedList: Blocked = {};
 
     private itemStatsWhitelist: SteamID[] = [];
 
@@ -678,6 +681,7 @@ export default class Bot {
             pricelist?: PricesDataObject;
             loginKey?: string;
             pollData?: TradeOfferManager.PollData;
+            blockedList?: Blocked;
         };
         let cookies: string[];
 
@@ -721,6 +725,11 @@ export default class Bot {
                             if (data.loginAttempts) {
                                 log.debug('Setting login attempts');
                                 this.setLoginAttempts = data.loginAttempts;
+                            }
+
+                            if (data.blockedList) {
+                                log.debug('Loading blocked list data');
+                                this.blockedList = data.blockedList;
                             }
 
                             /* eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */

--- a/src/classes/Carts/UserCart.ts
+++ b/src/classes/Carts/UserCart.ts
@@ -20,6 +20,8 @@ export default class UserCart extends Cart {
      */
     private useKeys = true;
 
+    private partnerSteamID = this.partner.getSteamID64();
+
     protected async preSendOffer(): Promise<void> {
         const [banned, escrow] = await Promise.all([
             this.bot.checkBanned(this.partner),
@@ -31,8 +33,8 @@ export default class UserCart extends Cart {
         if (banned.isBanned) {
             this.bot.client.blockUser(this.partner, err => {
                 if (err) {
-                    log.error(`❌ Failed to block user ${this.partner.getSteamID64()}: `, err);
-                } else log.info(`✅ Successfully blocked user ${this.partner.getSteamID64()}`);
+                    log.error(`❌ Failed to block user ${this.partnerSteamID}: `, err);
+                } else log.info(`✅ Successfully blocked user ${this.partnerSteamID}`);
             });
 
             let checkResult = '';
@@ -46,6 +48,13 @@ export default class UserCart extends Cart {
                         checkResult += `(${index + 1}) ${website}: ${banned.contents[website]}`;
                     }
                 });
+
+                this.bot.handler.saveBlockedUser(
+                    this.partnerSteamID,
+                    `[onSendingOffer] Banned on ${Object.keys(banned.contents)
+                        .filter(website => banned.contents[website] !== 'clean')
+                        .join(', ')}`
+                );
             }
 
             return Promise.reject(
@@ -462,7 +471,7 @@ export default class UserCart extends Cart {
         try {
             await theirInventory.fetch();
         } catch (err) {
-            log.error(`Failed to load inventories (${this.partner.getSteamID64()}): `, err);
+            log.error(`Failed to load inventories (${this.partnerSteamID}): `, err);
             return Promise.reject(
                 'Failed to load your inventory, Steam might be down. ' +
                     'Please try again later. If you have your profile/inventory set to private, please set it to public and try again.'

--- a/src/classes/Commands/sub-classes/Help.ts
+++ b/src/classes/Commands/sub-classes/Help.ts
@@ -83,7 +83,7 @@ export default class HelpCommands {
                         '!use (sku|assetid)=<a> - Use an item (such as Gift-Stuffed Stocking 2020 - sku: 5923;6;untradable).',
                         "!delete (sku|assetid)=<a> - Delete an item from the bot's inventory (SKU input only) 🚮",
                         '!message <steamid> <your message> - Send a message to a specific user 💬',
-                        '!block <steamid> [reason] - Block a specific user, reason will be save for future reference.',
+                        '!block <steamid> [reason] - Block a specific user, reason will be saved for future reference.',
                         '!unblock <steamid> - Unblock a specific user.',
                         '!blockedList - Get a list of blocked SteamIDs (with reason if any).',
                         '!clearfriends - Clear friendlist (will keep admins and friendsToKeep) 👋',

--- a/src/classes/Commands/sub-classes/Help.ts
+++ b/src/classes/Commands/sub-classes/Help.ts
@@ -76,16 +76,16 @@ export default class HelpCommands {
                 steamID,
                 '.\n✨=== Bot manager ===✨\n- ' +
                     [
-                        '!deposit (sku|name|defindex)=<a>&amount=<number> - Deposit items',
-                        '!withdraw (sku|name|defindex)=<a>&amount=<number> - Withdraw items',
-                        '!withdrawMptf [max=<number>] - [Exclusive Marketplace.tf Sellers] Withdraw items that does not exist on Marketplace.tf Dashboard items',
-                        "!expand craftable=(true|false) - Use Backpack Expanders to increase the bot's inventory limit",
-                        '!use (sku|assetid)=<a> - Use an item (such as Gift-Stuffed Stocking 2020 - sku: 5923;6;untradable)',
+                        '!deposit (sku|name|defindex)=<a>&amount=<number> - Deposit items.',
+                        '!withdraw (sku|name|defindex)=<a>&amount=<number> - Withdraw items.',
+                        '!withdrawMptf [max=<number>] - [Exclusive Marketplace.tf Sellers] Withdraw items that does not exist on Marketplace.tf Dashboard items.',
+                        "!expand craftable=(true|false) - Use Backpack Expanders to increase the bot's inventory limit.",
+                        '!use (sku|assetid)=<a> - Use an item (such as Gift-Stuffed Stocking 2020 - sku: 5923;6;untradable).',
                         "!delete (sku|assetid)=<a> - Delete an item from the bot's inventory (SKU input only) 🚮",
                         '!message <steamid> <your message> - Send a message to a specific user 💬',
-                        '!block <steamid> - Block a specific user',
-                        '!unblock <steamid> - Unblock a specific user',
-                        '!blockedList - Get a list of blocked users',
+                        '!block <steamid> [reason] - Block a specific user, reason will be save for future reference.',
+                        '!unblock <steamid> - Unblock a specific user.',
+                        '!blockedList - Get a list of blocked SteamIDs (with reason if any).',
                         '!clearfriends - Clear friendlist (will keep admins and friendsToKeep) 👋',
                         '!stop - Stop the bot 🔴',
                         '!restart - Restart the bot 🔄',
@@ -94,11 +94,11 @@ export default class HelpCommands {
                         '!haltstatus - Get the info whether the bot is paused or not ⏯',
                         "!refreshautokeys - Refresh the bot's autokeys settings.",
                         '!refreshlist - Refresh sell listings 🔄',
-                        "!name <new_name> - Change the bot's name",
-                        "!avatar <image_URL> - Change the bot's avatar",
+                        "!name <new_name> - Change the bot's name.",
+                        "!avatar <image_URL> - Change the bot's avatar.",
                         '!donatebptf (sku|name|defindex)=<a>&amount=<integer> - Donate to backpack.tf (https://backpack.tf/donate) 💰',
                         '!premium months=<integer> - Purchase backpack.tf premium using keys (https://backpack.tf/premium/subscribe) 👑',
-                        '!refreshSchema - Force refresh TF2 Schema when new update arrived (do not spam this)'
+                        '!refreshSchema - Force refresh TF2 Schema when new update arrived (do not spam this).'
                     ].join('\n- ')
             );
 

--- a/src/classes/Commands/sub-classes/Manager.ts
+++ b/src/classes/Commands/sub-classes/Manager.ts
@@ -285,7 +285,7 @@ export default class ManagerCommands {
 
         const sendBlockedList = async (blockedFriends: string[]) => {
             const toSend = blockedFriends.map(
-                id => `${id}${this.bot.blockedList[id] ? ` - ${this.bot.blockedList[id]}` : ''}`
+                (id, index) => `${index + 1}. ${id}${this.bot.blockedList[id] ? ` - ${this.bot.blockedList[id]}` : ''}`
             );
             const toSendCount = toSend.length;
 

--- a/src/classes/Commands/sub-classes/Message.ts
+++ b/src/classes/Commands/sub-classes/Message.ts
@@ -69,7 +69,7 @@ export default class MessageCommand {
 
             const recipientDetails = this.bot.friends.getFriend(recipientSteamID);
             const adminDetails = this.bot.friends.getFriend(steamID);
-            const reply = steamIdAndMessage.substr(steamIDString.length);
+            const reply = steamIdAndMessage.substring(steamIDString.length).trim();
             const isShowOwner = optComm.showOwnerName;
 
             // Send message to recipient
@@ -129,7 +129,7 @@ export default class MessageCommand {
                 );
             }
 
-            const msg = message.substr(message.toLowerCase().indexOf('message') + 8);
+            const msg = message.substring(8).trim(); // "message"
             if (!msg) {
                 return this.bot.sendMessage(
                     steamID,

--- a/src/classes/Commands/sub-classes/Review.ts
+++ b/src/classes/Commands/sub-classes/Review.ts
@@ -227,7 +227,7 @@ export default class ReviewCommands {
             this.bot.sendMessage(steamID, `${isAccepting ? 'Accepting' : 'Declining'} offer...`);
 
             const partnerId = new SteamID(this.bot.manager.pollData.offerData[offerId].partner);
-            const reply = offerIdAndMessage.substr(offerId.length);
+            const reply = offerIdAndMessage.substring(offerId.length).trim();
             const adminDetails = this.bot.friends.getFriend(steamID);
 
             try {
@@ -316,7 +316,7 @@ export default class ReviewCommands {
             this.bot.sendMessage(steamID, `Force ${isForceAccepting ? 'accepting' : 'declining'} offer...`);
 
             const partnerId = new SteamID(this.bot.manager.pollData.offerData[offerId].partner);
-            const reply = offerIdAndMessage.substr(offerId.length);
+            const reply = offerIdAndMessage.substring(offerId.length).trim();
             const adminDetails = this.bot.friends.getFriend(steamID);
 
             try {

--- a/src/classes/Handler.ts
+++ b/src/classes/Handler.ts
@@ -4,6 +4,15 @@ import SteamID from 'steamid';
 import TradeOfferManager, { PollData, Meta } from '@tf2autobot/tradeoffer-manager';
 import Bot from './Bot';
 import { Entry, PricesDataObject, PricesObject } from './Pricelist';
+import { Blocked } from './MyHandler/interfaces';
+
+export interface OnRun {
+    loginAttempts?: number[];
+    pricelist?: PricesDataObject;
+    loginKey?: string;
+    pollData?: PollData;
+    blockedList?: Blocked;
+}
 
 export default abstract class Handler {
     protected constructor(readonly bot: Bot) {
@@ -17,12 +26,7 @@ export default abstract class Handler {
     /**
      * Called when the bot is first started
      */
-    abstract onRun(): Promise<{
-        loginAttempts?: number[];
-        pricelist?: PricesDataObject;
-        loginKey?: string;
-        pollData?: PollData;
-    }>;
+    abstract onRun(): Promise<OnRun>;
 
     /**
      * Called when the bot has started

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -24,9 +24,9 @@ import processDeclined from './offer/processDeclined';
 import { sendReview } from './offer/review/export-review';
 import { keepMetalSupply, craftDuplicateWeapons, craftClassWeapons } from './utils/export-utils';
 
-import { BPTFGetUserInfo } from './interfaces';
+import { Blocked, BPTFGetUserInfo } from './interfaces';
 
-import Handler from '../Handler';
+import Handler, { OnRun } from '../Handler';
 import Bot from '../Bot';
 import { Entry, PricesDataObject, PricesObject } from '../Pricelist';
 import Commands from '../Commands/Commands';
@@ -210,10 +210,19 @@ export default class MyHandler extends Handler {
             files.readFile(this.paths.files.loginKey, false),
             files.readFile(this.paths.files.pricelist, true),
             files.readFile(this.paths.files.loginAttempts, true),
-            files.readFile(this.paths.files.pollData, true)
-        ]).then(([loginKey, pricelist, loginAttempts, pollData]: [string, PricesDataObject, number[], PollData]) => {
-            return { loginKey, pricelist, loginAttempts, pollData };
-        });
+            files.readFile(this.paths.files.pollData, true),
+            files.readFile(this.paths.files.blockedList, true)
+        ]).then(
+            ([loginKey, pricelist, loginAttempts, pollData, blockedList]: [
+                string,
+                PricesDataObject,
+                number[],
+                PollData,
+                Blocked
+            ]) => {
+                return { loginKey, pricelist, loginAttempts, pollData, blockedList };
+            }
+        );
     }
 
     onReady(): void {
@@ -523,6 +532,7 @@ export default class MyHandler extends Handler {
 
         const opt = this.opt;
         const isAdmin = this.bot.isAdmin(offer.partner);
+        const partnerSteamID = offer.partner.getSteamID64();
 
         const items = {
             our: Inventory.fromItems(
@@ -699,14 +709,11 @@ export default class MyHandler extends Handler {
 
             if (opt.sendAlert.enable && opt.sendAlert.unableToProcessOffer) {
                 if (optDw.sendAlert.enable && optDw.sendAlert.url.main !== '') {
-                    sendAlert('failed-processing-offer', this.bot, null, null, null, [
-                        offer.partner.getSteamID64(),
-                        offer.id
-                    ]);
+                    sendAlert('failed-processing-offer', this.bot, null, null, null, [partnerSteamID, offer.id]);
                 } else {
                     this.bot.messageAdmins(
                         '',
-                        `Unable to process offer #${offer.id} with ${offer.partner.getSteamID64()}.` +
+                        `Unable to process offer #${offer.id} with ${partnerSteamID}.` +
                             ' The offer data received was broken because our side and their side are both empty.' +
                             `\nPlease manually check the offer (login as me): https://steamcommunity.com/tradeoffer/${offer.id}/` +
                             `\nSend "!faccept ${offer.id}" to force accept, or "!fdecline ${offer.id}" to decline.`,
@@ -770,15 +777,22 @@ export default class MyHandler extends Handler {
         offer.log('info', 'checking bans...');
 
         try {
-            const isBanned = await this.bot.checkBanned(offer.partner.getSteamID64());
+            const isBanned = await this.bot.checkBanned(partnerSteamID);
 
             if (isBanned.isBanned) {
                 offer.log('info', 'partner is banned in one or more communities, declining...');
                 this.bot.client.blockUser(offer.partner, err => {
                     if (err) {
-                        log.warn(`❌ Failed to block user ${offer.partner.getSteamID64()}: `, err);
-                    } else log.info(`✅ Successfully blocked user ${offer.partner.getSteamID64()}`);
+                        log.warn(`❌ Failed to block user ${partnerSteamID}: `, err);
+                    } else log.info(`✅ Successfully blocked user ${partnerSteamID}`);
                 });
+
+                this.saveBlockedUser(
+                    partnerSteamID,
+                    `[onReceivedOffer] Banned on ${Object.keys(isBanned.contents)
+                        .filter(website => isBanned.contents[website] !== 'clean')
+                        .join(', ')}`
+                );
 
                 return {
                     action: 'decline',
@@ -2361,6 +2375,25 @@ export default class MyHandler extends Handler {
         this.bot.listings.checkBySKU(sku, entry, false, true);
     }
 
+    saveBlockedUser(steamID: string, reason: string): void {
+        if (reason) {
+            // Will add or replace new one, if reason is defined
+            this.bot.blockedList[steamID] = reason;
+
+            files.writeFile(this.paths.files.blockedList, this.bot.blockedList, true).catch(err => {
+                log.warn('Failed to save blockedList: ', err);
+            });
+        }
+    }
+
+    removeBlockedUser(steamID: string): void {
+        delete this.bot.blockedList[steamID];
+
+        files.writeFile(this.paths.files.blockedList, this.bot.blockedList, true).catch(err => {
+            log.warn('Failed to update blockedList: ', err);
+        });
+    }
+
     onUserAgent(pulse: { status: string; current_time?: number; expire_at?: number; client?: string }): void {
         if (pulse.client) {
             delete pulse.client;
@@ -2408,13 +2441,6 @@ export default class MyHandler extends Handler {
     onDeleteArchivedListingError(err: Error): void {
         log.error('Error on delete archived listings:', err);
     }
-}
-
-interface OnRun {
-    loginAttempts?: number[];
-    pricelist?: PricesDataObject;
-    loginKey?: string;
-    pollData?: PollData;
 }
 
 interface OnNewTradeOffer {

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -2153,6 +2153,13 @@ export default class MyHandler extends Handler {
                         } else log.info(`✅ Successfully blocked user ${steamID64}`);
                     });
 
+                    this.saveBlockedUser(
+                        steamID64,
+                        `[onFriendRequest] Banned on ${Object.keys(banned.contents)
+                            .filter(website => banned.contents[website] !== 'clean')
+                            .join(', ')}`
+                    );
+
                     return;
                 }
 

--- a/src/classes/MyHandler/interfaces.ts
+++ b/src/classes/MyHandler/interfaces.ts
@@ -77,3 +77,7 @@ interface BPTFTrust {
     positive?: number;
     negative?: number;
 }
+
+export interface Blocked {
+    [steamid: string]: string;
+}

--- a/src/resources/paths.ts
+++ b/src/resources/paths.ts
@@ -5,6 +5,7 @@ interface FilePaths {
     pollData: string;
     loginAttempts: string;
     pricelist: string;
+    blockedList: string;
 }
 
 interface LogPaths {
@@ -24,7 +25,8 @@ export default function genPaths(steamAccountName: string): Paths {
             loginKey: path.join(__dirname, `../../files/${steamAccountName}/loginkey.txt`),
             pollData: path.join(__dirname, `../../files/${steamAccountName}/polldata.json`),
             loginAttempts: path.join(__dirname, `../../files/${steamAccountName}/loginattempts.json`),
-            pricelist: path.join(__dirname, `../../files/${steamAccountName}/pricelist.json`)
+            pricelist: path.join(__dirname, `../../files/${steamAccountName}/pricelist.json`),
+            blockedList: path.join(__dirname, `../../files/${steamAccountName}/blockedList.json`)
         },
         logs: {
             log: path.join(__dirname, `../../logs/${steamAccountName}-%DATE%.log`),


### PR DESCRIPTION
An option to add a reason why a user is blocked for future reference (will be shown in the `!blockedList` command).

Usage: `!block <steamid> [reason]`
Example: `!block 7659358192 Trying to exploit`

You can also add the reason for already blocked users with the same command.

Also, note that people that are automatically blocked (during friend requests, receiving an offer, or sending an offer) will be automatically added with `[onFriendRequest]`, `[onReceivedOffer]`, and `[onSendingOffer]`, respectively.