### PR TITLE
🐛 fix wrong profit/loss from over/underpay info

### DIFF
--- a/src/classes/MyHandler/offer/accepted/processAccepted.ts
+++ b/src/classes/MyHandler/offer/accepted/processAccepted.ts
@@ -200,7 +200,7 @@ export default function processAccepted(
 
         const keyPrices = bot.pricelist.getKeyPrices;
 
-        const value = t.valueDiff(offer, keyPrices, isTradingKeys, opt.miscSettings.showOnlyMetal.enable);
+        const value = t.valueDiff(offer, keyPrices, isTradingKeys);
         const itemList = t.listItems(offer, bot, itemsName, true);
 
         void sendToAdmin(

--- a/src/classes/MyHandler/offer/notify/declined.ts
+++ b/src/classes/MyHandler/offer/notify/declined.ts
@@ -8,7 +8,7 @@ export default function declined(offer: TradeOffer, bot: Bot, isTradingKeys: boo
     const offerReason = offer.data('action') as Action;
     const meta = offer.data('meta') as Meta;
     const keyPrices = bot.pricelist.getKeyPrices;
-    const value = valueDiff(offer, keyPrices, isTradingKeys, opt.miscSettings.showOnlyMetal.enable);
+    const value = valueDiff(offer, keyPrices, isTradingKeys);
     const manualReviewDisabled = !opt.manualReview.enable;
 
     const declined = '/pre ❌ Ohh nooooes! The offer is no longer available. Reason: The offer has been declined';

--- a/src/classes/MyHandler/offer/processDeclined.ts
+++ b/src/classes/MyHandler/offer/processDeclined.ts
@@ -278,7 +278,7 @@ export default function processDeclined(offer: i.TradeOffer, bot: Bot, isTrading
             highValue: declined.highValue.concat(declined.highNotSellingItems)
         };
         const keyPrices = bot.pricelist.getKeyPrices;
-        const value = t.valueDiff(offer, keyPrices, isTradingKeys, opt.miscSettings.showOnlyMetal.enable);
+        const value = t.valueDiff(offer, keyPrices, isTradingKeys);
         const itemList = t.listItems(offer, bot, itemsName, true);
 
         sendToAdmin(bot, offer, value, itemList, keyPrices, isOfferSent, timeTakenToProcessOrConstruct);

--- a/src/classes/MyHandler/offer/review/process-review.ts
+++ b/src/classes/MyHandler/offer/review/process-review.ts
@@ -5,7 +5,7 @@ import { ValueDiff, valueDiff } from '../../../../lib/tools/export';
 
 export default function processReview(offer: TradeOffer, meta: Meta, bot: Bot, isTradingKeys: boolean): Content {
     const keyPrices = bot.pricelist.getKeyPrices;
-    const value = valueDiff(offer, keyPrices, isTradingKeys, bot.options.miscSettings.showOnlyMetal.enable);
+    const value = valueDiff(offer, keyPrices, isTradingKeys);
     const reasons = meta.uniqueReasons;
     const reviewReasons: string[] = [];
 

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -412,7 +412,7 @@ export default class Trades {
 
             if (opt.sendAlert.enable && opt.sendAlert.failedAccept) {
                 const keyPrices = this.bot.pricelist.getKeyPrices;
-                const value = t.valueDiff(offer, keyPrices, false, opt.miscSettings.showOnlyMetal.enable);
+                const value = t.valueDiff(offer, keyPrices, false);
 
                 if (opt.discordWebhook.sendAlert.enable && opt.discordWebhook.sendAlert.url.main !== '') {
                     const summary = t.summarizeToChat(
@@ -617,12 +617,7 @@ export default class Trades {
 
                             if (opt.sendAlert.enable && opt.sendAlert.failedAccept) {
                                 const keyPrices = this.bot.pricelist.getKeyPrices;
-                                const value = t.valueDiff(
-                                    offer,
-                                    keyPrices,
-                                    false,
-                                    opt.miscSettings.showOnlyMetal.enable
-                                );
+                                const value = t.valueDiff(offer, keyPrices, false);
 
                                 if (
                                     opt.discordWebhook.sendAlert.enable &&

--- a/src/lib/DiscordWebhook/sendTradeDeclined.ts
+++ b/src/lib/DiscordWebhook/sendTradeDeclined.ts
@@ -43,7 +43,7 @@ export default async function sendTradeDeclined(
           };
 
     const keyPrices = bot.pricelist.getKeyPrices;
-    const value = t.valueDiff(offer, keyPrices, isTradingKeys, optBot.miscSettings.showOnlyMetal.enable);
+    const value = t.valueDiff(offer, keyPrices, isTradingKeys);
     const summary = t.summarizeToChat(offer, bot, 'declined', true, value, keyPrices, false, isOfferSent);
 
     const details = await getPartnerDetails(offer, bot);

--- a/src/lib/DiscordWebhook/sendTradeSummary.ts
+++ b/src/lib/DiscordWebhook/sendTradeSummary.ts
@@ -44,7 +44,7 @@ export default async function sendTradeSummary(
           };
 
     const keyPrices = bot.pricelist.getKeyPrices;
-    const value = t.valueDiff(offer, keyPrices, isTradingKeys, optBot.miscSettings.showOnlyMetal.enable);
+    const value = t.valueDiff(offer, keyPrices, isTradingKeys);
     const summary = t.summarizeToChat(offer, bot, 'summary-accepted', true, value, keyPrices, false, isOfferSent);
 
     // Mention owner on the sku(s) specified in discordWebhook.tradeSummary.mentionOwner.itemSkus

--- a/src/lib/tools/valueDiff.ts
+++ b/src/lib/tools/valueDiff.ts
@@ -1,58 +1,38 @@
-import { ItemsValue, TradeOffer } from '@tf2autobot/tradeoffer-manager';
+import { TradeOffer } from '@tf2autobot/tradeoffer-manager';
 import Currencies from '@tf2autobot/tf2-currencies';
-import { Currency } from '../../types/TeamFortress2';
 import { KeyPrices } from '../../classes/Pricelist';
 
-export default function valueDiff(
-    offer: TradeOffer,
-    keyPrices: KeyPrices,
-    isTradingKeys: boolean,
-    enableShowOnlyMetal: boolean
-): ValueDiff {
-    const value = offer.data('value') as ItemsValue;
+export default function valueDiff(offer: TradeOffer, keyPrices: KeyPrices, isTradingKeys: boolean): ValueDiff {
+    let value = offer.data('value') as ItemValue;
 
     if (!value) {
         return { ourValue: 0, theirValue: 0, diff: 0, diffRef: 0, diffKey: '' };
     } else {
-        const newValue: { our: Currency; their: Currency } = {
-            our: {
-                keys: value.our.keys,
-                metal: value.our.metal
-            },
-            their: {
-                keys: value.their.keys,
-                metal: value.their.metal
-            }
+        value = {
+            our: new Currencies({ keys: value.our.keys, metal: value.our.metal }),
+            their: new Currencies({ keys: value.their.keys, metal: value.their.metal })
         };
 
-        if (!enableShowOnlyMetal) {
-            // if ENABLE_SHOW_ONLY_METAL is set to false, then this need to be converted first.
-            newValue.our.metal = Currencies.toRefined(
-                Currencies.toScrap(newValue.our.metal) + newValue.our.keys * keyPrices.sell.toValue()
-            );
-            newValue.our.keys = 0;
-
-            // If trading keys, then their side need to use buying key price.
-            newValue.their.metal = Currencies.toRefined(
-                Currencies.toScrap(newValue.their.metal) +
-                    newValue.their.keys * (isTradingKeys ? keyPrices.buy.toValue() : keyPrices.sell.toValue())
-            );
-            newValue.their.keys = 0;
-        }
-
-        const diff = Currencies.toScrap(newValue.their.metal) - Currencies.toScrap(newValue.our.metal);
+        const ourValue = value.our.toValue(keyPrices.sell.metal);
+        const theirValue = value.their.toValue(isTradingKeys ? keyPrices.buy.metal : keyPrices.sell.metal);
+        const diff = theirValue - ourValue;
 
         return {
-            ourValue: Currencies.toScrap(newValue.our.metal),
-            theirValue: Currencies.toScrap(newValue.their.metal),
-            diff: diff,
+            ourValue,
+            theirValue,
+            diff,
             diffRef: Currencies.toRefined(Math.abs(diff)),
             diffKey: Currencies.toCurrencies(
                 Math.abs(diff),
-                Math.abs(diff) >= keyPrices.sell.metal ? keyPrices.sell.metal : undefined
+                Math.abs(diff) >= Currencies.toScrap(keyPrices.sell.metal) ? keyPrices.sell.metal : undefined
             ).toString()
         };
     }
+}
+
+interface ItemValue {
+    our: Currencies;
+    their: Currencies;
 }
 
 export interface ValueDiff {

--- a/src/lib/tools/valueDiff.ts
+++ b/src/lib/tools/valueDiff.ts
@@ -16,16 +16,14 @@ export default function valueDiff(offer: TradeOffer, keyPrices: KeyPrices, isTra
         const ourValue = value.our.toValue(keyPrices.sell.metal);
         const theirValue = value.their.toValue(isTradingKeys ? keyPrices.buy.metal : keyPrices.sell.metal);
         const diff = theirValue - ourValue;
+        const absoluteValue = Math.abs(diff);
 
         return {
             ourValue,
             theirValue,
             diff,
-            diffRef: Currencies.toRefined(Math.abs(diff)),
-            diffKey: Currencies.toCurrencies(
-                Math.abs(diff),
-                Math.abs(diff) >= Currencies.toScrap(keyPrices.sell.metal) ? keyPrices.sell.metal : undefined
-            ).toString()
+            diffRef: Currencies.toRefined(absoluteValue),
+            diffKey: Currencies.toCurrencies(absoluteValue, keyPrices.sell.metal).toString()
         };
     }
 }


### PR DESCRIPTION
This should fix this kind of problem:
(note: this problem is likely to happen if you set the `miscSettings.showOnlyMetal.enable` to `false`).
![image](https://user-images.githubusercontent.com/47635037/174067381-32547342-b2b9-43f9-9beb-3a23438cbf70.png)
![trade](https://cdn.discordapp.com/attachments/745410459212972173/985225751597043753/unknown.png)