### PR TITLE
Rotate polldata

### DIFF
--- a/src/classes/Commands/sub-classes/Status.ts
+++ b/src/classes/Commands/sub-classes/Status.ts
@@ -8,6 +8,7 @@ import Bot from '../../Bot';
 import CommandParser from '../../CommandParser';
 import { stats, profit, itemStats, testSKU } from '../../../lib/tools/export';
 import { sendStats } from '../../../lib/DiscordWebhook/export';
+import loadPollData from '../../../lib/tools/polldata';
 
 // Bot status
 
@@ -18,8 +19,9 @@ export default class StatusCommands {
 
     async statsCommand(steamID: SteamID): Promise<void> {
         const tradesFromEnv = this.bot.options.statistics.lastTotalTrades;
-        const trades = stats(this.bot);
-        const profits = await profit(this.bot, Math.floor((Date.now() - 86400000) / 1000)); //since -24h
+        const pollData = loadPollData(this.bot.handler.getPaths.files.dir);
+        const trades = stats(this.bot, pollData);
+        const profits = await profit(this.bot, pollData, Math.floor((Date.now() - 86400000) / 1000)); //since -24h
 
         const keyPrices = this.bot.pricelist.getKeyPrices;
 

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -174,6 +174,10 @@ export default class MyHandler extends Handler {
 
     private paths: Paths;
 
+    get getPaths(): Paths {
+        return this.paths;
+    }
+
     private isUpdating = false;
 
     set isUpdatingStatus(setStatus: boolean) {

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -56,32 +56,8 @@ export default class Trades {
     }
 
     setPollData(pollData: TradeOfferManager.PollData): void {
-        const activeOrCreatedNeedsConfirmation: string[] = [];
-
-        for (const id in pollData.sent) {
-            if (!Object.prototype.hasOwnProperty.call(pollData.sent, id)) {
-                continue;
-            }
-
-            const state = pollData.sent[id];
-            if (
-                state === TradeOfferManager.ETradeOfferState['Active'] ||
-                state === TradeOfferManager.ETradeOfferState['CreatedNeedsConfirmation']
-            ) {
-                activeOrCreatedNeedsConfirmation.push(id);
-            }
-        }
-
-        for (const id in pollData.received) {
-            if (!Object.prototype.hasOwnProperty.call(pollData.received, id)) {
-                continue;
-            }
-
-            const state = pollData.received[id];
-            if (state === TradeOfferManager.ETradeOfferState['Active']) {
-                activeOrCreatedNeedsConfirmation.push(id);
-            }
-        }
+        const active = this.getActiveOffers(pollData);
+        const activeOrCreatedNeedsConfirmation = active.sent.concat(active.received);
 
         // Go through all sent / received offers and mark the items as in trade
         const activeCount = activeOrCreatedNeedsConfirmation.length;
@@ -101,6 +77,38 @@ export default class Trades {
         }
 
         this.bot.manager.pollData = pollData;
+    }
+
+    getActiveOffers(pollData: TradeOfferManager.PollData) {
+        const sent: string[] = [];
+        const received: string[] = [];
+
+        for (const id in pollData.sent) {
+            if (!Object.prototype.hasOwnProperty.call(pollData.sent, id)) {
+                continue;
+            }
+
+            const state = pollData.sent[id];
+            if (
+                state === TradeOfferManager.ETradeOfferState['Active'] ||
+                state === TradeOfferManager.ETradeOfferState['CreatedNeedsConfirmation']
+            ) {
+                sent.push(id);
+            }
+        }
+
+        for (const id in pollData.received) {
+            if (!Object.prototype.hasOwnProperty.call(pollData.received, id)) {
+                continue;
+            }
+
+            const state = pollData.received[id];
+            if (state === TradeOfferManager.ETradeOfferState['Active']) {
+                received.push(id);
+            }
+        }
+
+        return { sent, received };
     }
 
     onNewOffer(offer: TradeOffer): void {

--- a/src/lib/DiscordWebhook/sendStats.ts
+++ b/src/lib/DiscordWebhook/sendStats.ts
@@ -6,12 +6,14 @@ import { Webhook } from './interfaces';
 import log from '../logger';
 import { stats, profit, timeNow } from '../../lib/tools/export';
 import Bot from '../../classes/Bot';
+import loadPollData from '../tools/polldata';
 
 export default async function sendStats(bot: Bot, forceSend = false, steamID?: SteamID): Promise<void> {
     const optDW = bot.options.discordWebhook;
     const botInfo = bot.handler.getBotInfo;
-    const trades = stats(bot);
-    const profits = await profit(bot, Math.floor((Date.now() - 86400000) / 1000));
+    const pollData = loadPollData(bot.handler.getPaths.files.dir);
+    const trades = stats(bot, pollData);
+    const profits = await profit(bot, pollData, Math.floor((Date.now() - 86400000) / 1000));
 
     const tradesFromEnv = bot.options.statistics.lastTotalTrades;
     const keyPrices = bot.pricelist.getKeyPrices;

--- a/src/lib/tools/polldata.ts
+++ b/src/lib/tools/polldata.ts
@@ -1,0 +1,43 @@
+import SteamTradeOfferManager from '@tf2autobot/tradeoffer-manager';
+import fs from 'fs';
+
+export default function loadPollData(dir: string) {
+    let polldata: SteamTradeOfferManager.PollData;
+
+    let init = false;
+
+    fs.readdirSync(dir)
+        .filter(name => name.includes('polldata'))
+        .map(name => {
+            return {
+                name: name,
+                mtime: fs.statSync(dir + name).mtimeMs
+            };
+        })
+        .sort((a, b) => a.mtime - b.mtime)
+        .forEach(e => {
+            const data = JSON.parse(
+                fs.readFileSync(dir + e.name, { encoding: 'utf8' })
+            ) as SteamTradeOfferManager.PollData;
+
+            if (!init) {
+                polldata = { ...data };
+                init = true;
+            } else {
+                for (const key in polldata) {
+                    if (key === 'offersSince') {
+                        // Keep offersSince from the oldest polldata file
+                        continue;
+                    }
+
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    polldata[key] = {
+                        ...polldata[key],
+                        ...data[key]
+                    };
+                }
+            }
+        });
+
+    return polldata;
+}

--- a/src/lib/tools/profit.ts
+++ b/src/lib/tools/profit.ts
@@ -19,7 +19,6 @@ interface OfferDataWithTime extends OfferData {
 
 export default async function profit(bot: Bot, pollData: SteamTradeOfferManager.PollData, start = 0): Promise<Profit> {
     return new Promise(resolve => {
-        // const pollData = loadPollData(bot.handler.getPaths.files.dir);
         const now = dayjs();
 
         if (pollData.offerData) {

--- a/src/lib/tools/profit.ts
+++ b/src/lib/tools/profit.ts
@@ -2,8 +2,7 @@ import Bot from '../../classes/Bot';
 import dayjs from 'dayjs';
 import { Currency } from '../../types/TeamFortress2';
 import Currencies from '@tf2autobot/tf2-currencies';
-import { OfferData } from '@tf2autobot/tradeoffer-manager';
-import loadPollData from './polldata';
+import SteamTradeOfferManager, { OfferData } from '@tf2autobot/tradeoffer-manager';
 
 // reference: https://github.com/ZeusJunior/tf2-automatic-gui/blob/master/app/profit.js
 
@@ -18,9 +17,9 @@ interface OfferDataWithTime extends OfferData {
     time: number;
 }
 
-export default async function profit(bot: Bot, start = 0): Promise<Profit> {
+export default async function profit(bot: Bot, pollData: SteamTradeOfferManager.PollData, start = 0): Promise<Profit> {
     return new Promise(resolve => {
-        const pollData = loadPollData(bot.handler.getPaths.files.dir);
+        // const pollData = loadPollData(bot.handler.getPaths.files.dir);
         const now = dayjs();
 
         if (pollData.offerData) {

--- a/src/lib/tools/profit.ts
+++ b/src/lib/tools/profit.ts
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import { Currency } from '../../types/TeamFortress2';
 import Currencies from '@tf2autobot/tf2-currencies';
 import { OfferData } from '@tf2autobot/tradeoffer-manager';
+import loadPollData from './polldata';
 
 // reference: https://github.com/ZeusJunior/tf2-automatic-gui/blob/master/app/profit.js
 
@@ -19,7 +20,7 @@ interface OfferDataWithTime extends OfferData {
 
 export default async function profit(bot: Bot, start = 0): Promise<Profit> {
     return new Promise(resolve => {
-        const pollData = bot.manager.pollData;
+        const pollData = loadPollData(bot.handler.getPaths.files.dir);
         const now = dayjs();
 
         if (pollData.offerData) {

--- a/src/lib/tools/stats.ts
+++ b/src/lib/tools/stats.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import Bot from '../../classes/Bot';
+import loadPollData from './polldata';
 
 export default function stats(bot: Bot): Stats {
     const now = dayjs();
@@ -40,7 +41,7 @@ export default function stats(bot: Bot): Stats {
     let isInvalid24Hours = 0;
     let isInvalidToday = 0;
 
-    const pollData = bot.manager.pollData;
+    const pollData = loadPollData(bot.handler.getPaths.files.dir);
     const oldestId = pollData.offerData === undefined ? undefined : Object.keys(pollData.offerData)[0];
     const timeSince =
         +bot.options.statistics.startingTimeInUnix === 0
@@ -48,7 +49,7 @@ export default function stats(bot: Bot): Stats {
             : +bot.options.statistics.startingTimeInUnix;
     const totalDays = !timeSince ? 0 : now.diff(dayjs.unix(timeSince), 'day');
 
-    const offerData = bot.manager.pollData.offerData;
+    const offerData = pollData.offerData;
     for (const offerID in offerData) {
         if (!Object.prototype.hasOwnProperty.call(offerData, offerID)) {
             continue;

--- a/src/lib/tools/stats.ts
+++ b/src/lib/tools/stats.ts
@@ -41,7 +41,6 @@ export default function stats(bot: Bot, pollData: SteamTradeOfferManager.PollDat
     let isInvalid24Hours = 0;
     let isInvalidToday = 0;
 
-    // const pollData = loadPollData(bot.handler.getPaths.files.dir);
     const oldestId = pollData.offerData === undefined ? undefined : Object.keys(pollData.offerData)[0];
     const timeSince =
         +bot.options.statistics.startingTimeInUnix === 0

--- a/src/lib/tools/stats.ts
+++ b/src/lib/tools/stats.ts
@@ -1,8 +1,8 @@
+import SteamTradeOfferManager from '@tf2autobot/tradeoffer-manager';
 import dayjs from 'dayjs';
 import Bot from '../../classes/Bot';
-import loadPollData from './polldata';
 
-export default function stats(bot: Bot): Stats {
+export default function stats(bot: Bot, pollData: SteamTradeOfferManager.PollData): Stats {
     const now = dayjs();
     const aDayAgo = dayjs().subtract(24, 'hour');
     const startOfDay = dayjs().startOf('day');
@@ -41,7 +41,7 @@ export default function stats(bot: Bot): Stats {
     let isInvalid24Hours = 0;
     let isInvalidToday = 0;
 
-    const pollData = loadPollData(bot.handler.getPaths.files.dir);
+    // const pollData = loadPollData(bot.handler.getPaths.files.dir);
     const oldestId = pollData.offerData === undefined ? undefined : Object.keys(pollData.offerData)[0];
     const timeSince =
         +bot.options.statistics.startingTimeInUnix === 0

--- a/src/resources/paths.ts
+++ b/src/resources/paths.ts
@@ -7,6 +7,7 @@ interface FilePaths {
     loginAttempts: string;
     pricelist: string;
     blockedList: string;
+    dir: string;
 }
 
 interface LogPaths {
@@ -39,7 +40,8 @@ export default function genPaths(steamAccountName: string): Paths {
             pollData: pollDataPath,
             loginAttempts: path.join(__dirname, `../../files/${steamAccountName}/loginattempts.json`),
             pricelist: path.join(__dirname, `../../files/${steamAccountName}/pricelist.json`),
-            blockedList: path.join(__dirname, `../../files/${steamAccountName}/blockedList.json`)
+            blockedList: path.join(__dirname, `../../files/${steamAccountName}/blockedList.json`),
+            dir: path.join(__dirname, `../../files/${steamAccountName}/`)
         },
         logs: {
             log: path.join(__dirname, `../../logs/${steamAccountName}-%DATE%.log`),

--- a/src/resources/paths.ts
+++ b/src/resources/paths.ts
@@ -25,12 +25,11 @@ function generatePollDataPath(steamAccountName: string, increment: number) {
     return path.join(__dirname, `../../files/${steamAccountName}/polldata${increment > 0 ? increment : ''}.json`);
 }
 
-export default function genPaths(steamAccountName: string): Paths {
+export default function genPaths(steamAccountName: string, maxPollDataSizeMB = 5): Paths {
     let increment = 0;
     let pollDataPath = generatePollDataPath(steamAccountName, increment);
 
-    // TODO: Make max file size configurable (?)
-    while (fs.existsSync(pollDataPath) && fs.statSync(pollDataPath).size / (1024 * 1024) > 5) {
+    while (fs.existsSync(pollDataPath) && fs.statSync(pollDataPath).size / (1024 * 1024) > maxPollDataSizeMB) {
         pollDataPath = generatePollDataPath(steamAccountName, ++increment);
     }
 

--- a/src/resources/paths.ts
+++ b/src/resources/paths.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import fs from 'fs';
 
 interface FilePaths {
     loginKey: string;
@@ -19,11 +20,23 @@ export interface Paths {
     logs: LogPaths;
 }
 
+function generatePollDataPath(steamAccountName: string, increment: number) {
+    return path.join(__dirname, `../../files/${steamAccountName}/polldata${increment > 0 ? increment : ''}.json`);
+}
+
 export default function genPaths(steamAccountName: string): Paths {
+    let increment = 0;
+    let pollDataPath = generatePollDataPath(steamAccountName, increment);
+
+    // TODO: Make max file size configurable (?)
+    while (fs.existsSync(pollDataPath) && fs.statSync(pollDataPath).size / (1024 * 1024) > 5) {
+        pollDataPath = generatePollDataPath(steamAccountName, ++increment);
+    }
+
     return {
         files: {
             loginKey: path.join(__dirname, `../../files/${steamAccountName}/loginkey.txt`),
-            pollData: path.join(__dirname, `../../files/${steamAccountName}/polldata.json`),
+            pollData: pollDataPath,
             loginAttempts: path.join(__dirname, `../../files/${steamAccountName}/loginattempts.json`),
             pricelist: path.join(__dirname, `../../files/${steamAccountName}/pricelist.json`),
             blockedList: path.join(__dirname, `../../files/${steamAccountName}/blockedList.json`)


### PR DESCRIPTION
Rotate polldata every time the file size exceeds 5 MBs

Some possible QoL changes for the future:
- Add an option to the config to customize the maximum size of each polldata file
  - Increasing the maximum size, while already having polldata files saved at a smaller size will cause the bot to start filling up the older, smaller sized files again, which means we will no longer be able to rely on modification date of the file to correctly sort our trades. All trades will have to be sorted in this case for the stats calculations, which will make it slower.
- Remove duplicate entries
  - Active trades and recently processed trades at the time of switching to a new polldata file will appear in both the old and the new file.
  - These duplicates are handled by using the most recent entry when loading and combining all the polldatas, so they won't cause any inaccuracies in our stats.
  - Keep in mind, removing these duplicates could cause the old file to fall back below the maximum size threshold
- Compress the older polldata files
  - Will slow down stats calculations