### PR TITLE
🧩 Make the bot recognize Strange Skins variants.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@tf2autobot/steamcommunity": "^3.45.3",
                 "@tf2autobot/tf2": "^1.2.1",
                 "@tf2autobot/tf2-currencies": "^2.0.1",
-                "@tf2autobot/tf2-schema": "^3.1.0",
+                "@tf2autobot/tf2-schema": "^3.2.0",
                 "@tf2autobot/tf2-sku": "^2.0.3",
                 "@tf2autobot/tradeoffer-manager": "^2.13.6",
                 "async": "^3.2.4",
@@ -2117,9 +2117,9 @@
             }
         },
         "node_modules/@tf2autobot/tf2-schema": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-3.1.0.tgz",
-            "integrity": "sha512-o+mlnJVcBtrEktACtUjcvCyUPf0QLR9iKD/sLOO+jjFCQGBL46aoSWy454DI0sAby2QwDnP4vPOqRcD8hC+gTg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-3.2.0.tgz",
+            "integrity": "sha512-GoKse4xBlp3107GPwa2+crzjMTMG29sIjPGpIPeN8XuKaAH60POc+814dFWfC4a61CvpZDqypjIurQBPs36CVA==",
             "dependencies": {
                 "@tf2autobot/tf2-sku": "^2.0.3",
                 "async": "^3.2.4",
@@ -13794,9 +13794,9 @@
             }
         },
         "@tf2autobot/tf2-schema": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-3.1.0.tgz",
-            "integrity": "sha512-o+mlnJVcBtrEktACtUjcvCyUPf0QLR9iKD/sLOO+jjFCQGBL46aoSWy454DI0sAby2QwDnP4vPOqRcD8hC+gTg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-3.2.0.tgz",
+            "integrity": "sha512-GoKse4xBlp3107GPwa2+crzjMTMG29sIjPGpIPeN8XuKaAH60POc+814dFWfC4a61CvpZDqypjIurQBPs36CVA==",
             "requires": {
                 "@tf2autobot/tf2-sku": "^2.0.3",
                 "async": "^3.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@tf2autobot/steamcommunity": "^3.45.3",
                 "@tf2autobot/tf2": "^1.2.1",
                 "@tf2autobot/tf2-currencies": "^2.0.1",
-                "@tf2autobot/tf2-schema": "^2.8.3",
+                "@tf2autobot/tf2-schema": "^3.1.0",
                 "@tf2autobot/tf2-sku": "^2.0.3",
                 "@tf2autobot/tradeoffer-manager": "^2.13.6",
                 "async": "^3.2.4",
@@ -2117,9 +2117,9 @@
             }
         },
         "node_modules/@tf2autobot/tf2-schema": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-2.8.3.tgz",
-            "integrity": "sha512-fx9oNXGuNMmmpfEIUtuccfwTw/NMfRocjoyryQc7E5i0G1fODt3DNB5HFCgZA/9lJejLb/kOIlFLpX0xr6W1FA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-3.1.0.tgz",
+            "integrity": "sha512-o+mlnJVcBtrEktACtUjcvCyUPf0QLR9iKD/sLOO+jjFCQGBL46aoSWy454DI0sAby2QwDnP4vPOqRcD8hC+gTg==",
             "dependencies": {
                 "@tf2autobot/tf2-sku": "^2.0.3",
                 "async": "^3.2.4",
@@ -13794,9 +13794,9 @@
             }
         },
         "@tf2autobot/tf2-schema": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-2.8.3.tgz",
-            "integrity": "sha512-fx9oNXGuNMmmpfEIUtuccfwTw/NMfRocjoyryQc7E5i0G1fODt3DNB5HFCgZA/9lJejLb/kOIlFLpX0xr6W1FA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-3.1.0.tgz",
+            "integrity": "sha512-o+mlnJVcBtrEktACtUjcvCyUPf0QLR9iKD/sLOO+jjFCQGBL46aoSWy454DI0sAby2QwDnP4vPOqRcD8hC+gTg==",
             "requires": {
                 "@tf2autobot/tf2-sku": "^2.0.3",
                 "async": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@tf2autobot/steamcommunity": "^3.45.3",
         "@tf2autobot/tf2": "^1.2.1",
         "@tf2autobot/tf2-currencies": "^2.0.1",
-        "@tf2autobot/tf2-schema": "^3.1.0",
+        "@tf2autobot/tf2-schema": "^3.2.0",
         "@tf2autobot/tf2-sku": "^2.0.3",
         "@tf2autobot/tradeoffer-manager": "^2.13.6",
         "async": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@tf2autobot/steamcommunity": "^3.45.3",
         "@tf2autobot/tf2": "^1.2.1",
         "@tf2autobot/tf2-currencies": "^2.0.1",
-        "@tf2autobot/tf2-schema": "^2.8.3",
+        "@tf2autobot/tf2-schema": "^3.1.0",
         "@tf2autobot/tf2-sku": "^2.0.3",
         "@tf2autobot/tradeoffer-manager": "^2.13.6",
         "async": "^3.2.4",

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -5,7 +5,7 @@ import Currencies from '@tf2autobot/tf2-currencies';
 import dayjs from 'dayjs';
 
 import * as c from './sub-classes/export';
-import { removeLinkProtocol, getItemFromParams, getItemAndAmount, fixSKU } from './functions/utils';
+import { removeLinkProtocol, getItemFromParams, getItemAndAmount } from './functions/utils';
 
 import Bot from '../Bot';
 import CommandParser from '../CommandParser';
@@ -858,7 +858,7 @@ export default class Commands {
             params.sku = SKU.fromObject(fixItem(SKU.fromString(params.sku as string), this.bot.schema));
         }
 
-        const sku = fixSKU(params.sku as string);
+        const sku = params.sku as string;
 
         const amount = typeof params.amount === 'number' ? params.amount : 1;
         if (!Number.isInteger(amount)) {
@@ -961,7 +961,7 @@ export default class Commands {
             params.sku = SKU.fromObject(fixItem(SKU.fromString(params.sku as string), this.bot.schema));
         }
 
-        const sku = fixSKU(params.sku as string);
+        const sku = params.sku as string;
 
         let amount = typeof params.amount === 'number' ? params.amount : 1;
         if (!Number.isInteger(amount)) {

--- a/src/classes/Commands/functions/utils.ts
+++ b/src/classes/Commands/functions/utils.ts
@@ -686,18 +686,6 @@ export function getItemFromParams(
     return fixItem(item, bot.schema);
 }
 
-export function fixSKU(sku: string): string {
-    if (sku.includes(';15') && sku.includes(';strange')) {
-        // Only fix for Strange War Paint/Skins and Strange Unusual War Paint/Skins (weird variant)
-        const item = SKU.fromString(sku);
-        item.quality = 11;
-        item.quality2 = null;
-        return SKU.fromObject(item);
-    }
-
-    return sku;
-}
-
 export function removeLinkProtocol(message: string): string {
     return message.replace(/(\w+:|^)\/\//g, '');
 }

--- a/src/classes/Commands/sub-classes/Manager.ts
+++ b/src/classes/Commands/sub-classes/Manager.ts
@@ -10,7 +10,7 @@ import sleepasync from 'sleep-async';
 import dayjs from 'dayjs';
 import { EPersonaState } from 'steam-user';
 import { EFriendRelationship } from 'steam-user';
-import { fixSKU, removeLinkProtocol } from '../functions/utils';
+import { removeLinkProtocol } from '../functions/utils';
 import Bot from '../../Bot';
 import CommandParser from '../../CommandParser';
 import log from '../../../lib/logger';
@@ -172,7 +172,7 @@ export default class ManagerCommands {
                 );
             }
 
-            const targetedSKU = fixSKU(params.sku as string);
+            const targetedSKU = params.sku as string;
             const [uncraft, untrade] = [
                 targetedSKU.includes(';uncraftable'),
                 targetedSKU.includes(';untradable') || targetedSKU.includes(';untradeable')

--- a/src/classes/Commands/sub-classes/PricelistManager.ts
+++ b/src/classes/Commands/sub-classes/PricelistManager.ts
@@ -8,7 +8,7 @@ import pluralize from 'pluralize';
 import dayjs from 'dayjs';
 import sleepasync from 'sleep-async';
 import { UnknownDictionary, UnknownDictionaryKnownValues } from '../../../types/common';
-import { removeLinkProtocol, getItemFromParams, fixSKU } from '../functions/utils';
+import { removeLinkProtocol, getItemFromParams } from '../functions/utils';
 import Bot from '../../Bot';
 import CommandParser from '../../CommandParser';
 import { Entry, EntryData, PricelistChangedSource } from '../../Pricelist';
@@ -173,7 +173,7 @@ export default class PricelistManagerCommands {
             }
         }
 
-        params.sku = fixSKU(params.sku as string);
+        params.sku = params.sku as string;
 
         return this.bot.pricelist
             .addPrice(params as EntryData, true, PricelistChangedSource.Command)
@@ -255,7 +255,7 @@ export default class PricelistManagerCommands {
                 }
             }
 
-            params.sku = fixSKU(params.sku as string);
+            params.sku = params.sku as string;
 
             if (params.enabled === undefined) {
                 params.enabled = true;
@@ -983,7 +983,7 @@ export default class PricelistManagerCommands {
             params.sku = SKU.fromObject(item);
         }
 
-        params.sku = fixSKU(params.sku as string);
+        params.sku = params.sku as string;
 
         if (!this.bot.pricelist.hasPrice(params.sku as string)) {
             return this.bot.sendMessage(steamID, '❌ Item is not in the pricelist.');
@@ -1651,7 +1651,7 @@ export default class PricelistManagerCommands {
         }
 
         this.bot.pricelist
-            .removePrice(fixSKU(sku), true)
+            .removePrice(sku, true)
             .then(entry => {
                 this.bot.sendMessage(steamID, `✅ Removed "${entry.name}".`);
             })
@@ -1865,8 +1865,6 @@ export default class PricelistManagerCommands {
         if (sku === undefined) {
             return this.bot.sendMessage(steamID, '❌ Missing item');
         }
-
-        sku = fixSKU(sku);
 
         const match = this.bot.pricelist.getPrice(sku);
         if (match === null) {

--- a/src/classes/Commands/sub-classes/Request.ts
+++ b/src/classes/Commands/sub-classes/Request.ts
@@ -3,7 +3,7 @@ import SKU from '@tf2autobot/tf2-sku';
 import pluralize from 'pluralize';
 import sleepasync from 'sleep-async';
 import Currencies from '@tf2autobot/tf2-currencies';
-import { removeLinkProtocol, getItemFromParams, fixSKU } from '../functions/utils';
+import { removeLinkProtocol, getItemFromParams } from '../functions/utils';
 import Bot from '../../Bot';
 import CommandParser from '../../CommandParser';
 import log from '../../../lib/logger';
@@ -38,8 +38,6 @@ export default class RequestCommands {
         } else {
             sku = SKU.fromObject(fixItem(SKU.fromString(sku), this.bot.schema));
         }
-
-        sku = fixSKU(sku);
 
         void this.priceSource
             .requestCheck(sku)
@@ -114,8 +112,6 @@ export default class RequestCommands {
         } else {
             sku = SKU.fromObject(fixItem(SKU.fromString(sku), this.bot.schema));
         }
-
-        sku = fixSKU(sku);
 
         const name = this.bot.schema.getName(SKU.fromString(sku));
         try {

--- a/src/classes/Commands/sub-classes/Status.ts
+++ b/src/classes/Commands/sub-classes/Status.ts
@@ -3,7 +3,6 @@ import pluralize from 'pluralize';
 import Currencies from '@tf2autobot/tf2-currencies';
 import SKU from '@tf2autobot/tf2-sku';
 import sleepasync from 'sleep-async';
-import { fixSKU } from '../functions/utils';
 import Bot from '../../Bot';
 import CommandParser from '../../CommandParser';
 import { stats, profit, itemStats, testSKU } from '../../../lib/tools/export';
@@ -127,7 +126,6 @@ export default class StatusCommands {
             }
         }
 
-        sku = fixSKU(sku);
         let isSendSeparately = false;
         let boughtMessage = '';
         let soldMessage = '';

--- a/src/lib/extend/item/getSKU.ts
+++ b/src/lib/extend/item/getSKU.ts
@@ -8,6 +8,8 @@ import { fixItem } from '../../items';
 
 let isCrate = false;
 let isPainted = false;
+let replaceQualityTo11 = false;
+let replaceQualityTo15 = false;
 
 export = function (
     schema: SchemaManager.Schema,
@@ -21,6 +23,8 @@ export = function (
 
     isCrate = false;
     isPainted = false;
+    replaceQualityTo11 = false;
+    replaceQualityTo15 = false;
 
     if (self.appid != 440) {
         if (self.type && self.market_name) {
@@ -56,6 +60,14 @@ export = function (
 
     if (item.target === null) {
         item.target = getTarget(self, schema);
+    }
+
+    if (replaceQualityTo15) {
+        item.quality = 15;
+    }
+
+    if (replaceQualityTo11) {
+        item.quality = 11;
     }
 
     // Add missing properties, except if crates
@@ -256,6 +268,20 @@ function getElevatedQuality(
         item.hasDescription('Strange Stat Clock Attached') ||
         ((isUnusualHat || isOtherItemsNotStrangeQuality) && isNotNormalized)
     ) {
+        if (getPaintKit(item, schema) !== null) {
+            const hasRarityGradeTag = item.tags?.some(
+                tag => tag.category === 'Rarity' && tag.category_name === 'Grade'
+            );
+            const hasWarPaintTypeTag = item.getItemTag('Type') === 'War Paint';
+
+            if (hasWarPaintTypeTag || !hasRarityGradeTag) {
+                replaceQualityTo11 = true;
+                return null;
+            } else if (hasRarityGradeTag && quality === 11) {
+                replaceQualityTo15 = true;
+                return 11;
+            }
+        }
         return 11;
     } else {
         return null;

--- a/src/lib/items.ts
+++ b/src/lib/items.ts
@@ -155,17 +155,10 @@ export function fixItem(item: MinimumItem, schema: SchemaManager.Schema): Minimu
             item.quality = 5;
         } else if (item.paintkit !== null) {
             // War Paint or Skins
-            if (item.quality2 === 11) {
+            if (item.quality2 === 11 || item.quality === 5) {
                 // Strange Unusual
-                item.quality = 11;
-                item.quality2 = null;
+                item.quality = 15;
             }
-        }
-    } else if (item.paintkit !== null) {
-        // War Paint or Skins (No effect)
-        if (item.quality2 === 11) {
-            item.quality = 11;
-            item.quality2 = null;
         }
     }
 


### PR DESCRIPTION
Revoking changes made on #394, which means you will be able to add Strange Decorated Weapon (or Skins) that has two different Strange variants (one with quality Strange, and the other one with quality Decorated Weapon and elevated quality Strange).

The bot will no longer recognize the two variants as the same item.

Also:
Any sku with `;strange` (Elevated Strange Quality) on Decorated Weapons (or Skins) will now generate an item name with `(e)` (explicit) on it.

Example:
- `197;15;u703;w2;pk200;strange;kt-3`: Strange(e) Cool Professional Killstreak Bloom Buffed Wrench (Minimal Wear)
- `31024;5;u17;strange`: Strange Sunbeams Crack Pot
- `336;3;strange`: Strange Vintage Stockbroker's Scarf
- `878;1;strange`: Strange Genuine Foppish Physician
- `30498;13;strange`: Strange Haunted Hooded Haunter

When using the `!sku`, or the `!buy`/`!sell`/`!buycart`/`!sellcart` commands, the sku generated will be:
- Strange Cool Professional Killstreak Bloom Buffed Wrench (Minimal Wear): `197;11;u703;w2;pk200;kt-3`
- Strange(e) Cool Professional Killstreak Bloom Buffed Wrench (Minimal Wear): `197;15;u703;w2;pk200;strange;kt-3`
- Strange Sunbeams Crack Pot: `31024;5;u17;strange`
- Strange(e) Sunbeams Crack Pot: `31024;5;u17;strange` (same)
