### PR TITLE
Reduce memory usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@tf2autobot/tf2-currencies": "^2.0.1",
                 "@tf2autobot/tf2-schema": "^3.2.0",
                 "@tf2autobot/tf2-sku": "^2.0.3",
-                "@tf2autobot/tradeoffer-manager": "^2.13.6",
+                "@tf2autobot/tradeoffer-manager": "^2.14.0",
                 "async": "^3.2.4",
                 "axios": "^0.27.2",
                 "bluebird": "^3.7.2",
@@ -2085,9 +2085,9 @@
             }
         },
         "node_modules/@tf2autobot/tradeoffer-manager": {
-            "version": "2.13.6",
-            "resolved": "https://registry.npmjs.org/@tf2autobot/tradeoffer-manager/-/tradeoffer-manager-2.13.6.tgz",
-            "integrity": "sha512-bwVcvVV9Zt2UU0pea+WRB671QAtrBIGf48zp8pk3dZ995fA9o14118/4G7/iCrZly2P2c69QfyyeEePViiQXjA==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/@tf2autobot/tradeoffer-manager/-/tradeoffer-manager-2.14.0.tgz",
+            "integrity": "sha512-QnZ+fQ+Sp1N4o2JVGtZJWSQ0LZos9nh+hlszVEKm28kVnQ6SRn5KyXsLWXbpoygqkOTfpdKkx8H6HKo0NbQ68w==",
             "dependencies": {
                 "@doctormckay/stdlib": "^1.5.1",
                 "@tf2autobot/steamcommunity": "^3.45.3",
@@ -7779,7 +7779,7 @@
         "node_modules/languages": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/languages/-/languages-0.1.3.tgz",
-            "integrity": "sha1-8ZJzuw6Uas0t6xDAfHUO4Si91LA="
+            "integrity": "sha512-E+u0KJ9LmqUx/O1y+5ALmjjBXy448JeXyWaYFOPj269EHnHoQYjYdLhejt1oe/2dUb8L98tJDCnmRRoJFr1mNw=="
         },
         "node_modules/lazy": {
             "version": "1.0.11",
@@ -12372,9 +12372,9 @@
             }
         },
         "@tf2autobot/tradeoffer-manager": {
-            "version": "2.13.6",
-            "resolved": "https://registry.npmjs.org/@tf2autobot/tradeoffer-manager/-/tradeoffer-manager-2.13.6.tgz",
-            "integrity": "sha512-bwVcvVV9Zt2UU0pea+WRB671QAtrBIGf48zp8pk3dZ995fA9o14118/4G7/iCrZly2P2c69QfyyeEePViiQXjA==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/@tf2autobot/tradeoffer-manager/-/tradeoffer-manager-2.14.0.tgz",
+            "integrity": "sha512-QnZ+fQ+Sp1N4o2JVGtZJWSQ0LZos9nh+hlszVEKm28kVnQ6SRn5KyXsLWXbpoygqkOTfpdKkx8H6HKo0NbQ68w==",
             "requires": {
                 "@doctormckay/stdlib": "^1.5.1",
                 "@tf2autobot/steamcommunity": "^3.45.3",
@@ -16680,7 +16680,7 @@
         "languages": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/languages/-/languages-0.1.3.tgz",
-            "integrity": "sha1-8ZJzuw6Uas0t6xDAfHUO4Si91LA="
+            "integrity": "sha512-E+u0KJ9LmqUx/O1y+5ALmjjBXy448JeXyWaYFOPj269EHnHoQYjYdLhejt1oe/2dUb8L98tJDCnmRRoJFr1mNw=="
         },
         "lazy": {
             "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@tf2autobot/tf2-currencies": "^2.0.1",
         "@tf2autobot/tf2-schema": "^3.2.0",
         "@tf2autobot/tf2-sku": "^2.0.3",
-        "@tf2autobot/tradeoffer-manager": "^2.13.6",
+        "@tf2autobot/tradeoffer-manager": "^2.14.0",
         "async": "^3.2.4",
         "axios": "^0.27.2",
         "bluebird": "^3.7.2",

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -150,7 +150,9 @@ export default class Bot {
             language: 'en',
             pollInterval: -1,
             cancelTime: 15 * 60 * 1000,
-            pendingCancelTime: 1.5 * 60 * 1000
+            pendingCancelTime: 1.5 * 60 * 1000,
+            globalAssetCache: true,
+            assetCacheMaxItems: 50
         });
 
         this.bptf = new BptfLogin();
@@ -1035,7 +1037,7 @@ export default class Bot {
                         return resolve();
                     }
 
-                    this.manager.pollInterval = 5 * 1000;
+                    this.manager.pollInterval = 60 * 1000;
                     this.setReady = true;
                     this.handler.onReady();
                     this.manager.doPoll();

--- a/src/classes/Commands/sub-classes/Manager.ts
+++ b/src/classes/Commands/sub-classes/Manager.ts
@@ -931,7 +931,7 @@ export default class ManagerCommands {
                     // Bring back online
                     this.bot.client.setPersona(EPersonaState.Online);
                     this.bot.handler.isUpdatingStatus = false;
-                    this.bot.manager.pollInterval = 5 * 1000;
+                    this.bot.manager.pollInterval = 60 * 1000;
                 };
 
                 try {

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -138,10 +138,7 @@ export default class Trades {
         const activeReceived = received.filter(offer => offer.state === TradeOfferManager.ETradeOfferState['Active']);
         const activeReceivedCount = activeReceived.length;
 
-        if (
-            filter === TradeOfferManager.EOfferFilter['ActiveOnly'] &&
-            (this.pollCount * this.bot.manager.pollInterval) / (2 * 5 * 60 * 1000) >= 1
-        ) {
+        if (filter === TradeOfferManager.EOfferFilter['ActiveOnly'] && this.pollCount / 5 >= 1) {
             this.pollCount = 0;
 
             const activeSent = sent.filter(offer => offer.state === TradeOfferManager.ETradeOfferState['Active']);


### PR DESCRIPTION
Should help with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` problem, which crashes the bot. This will also significantly help reduce memory usage.
From the latest changes made on [TF2Autobot/tradeoffer-manager](https://github.com/TF2Autobot/tradeoffer-manager), the bot will only cache trade history for only [up to 200 trades only](https://github.com/TF2Autobot/node-steam-tradeoffer-manager/commit/4f55e65c8e3865123d5c4eff99059d5fe53f232a), from the original 1100.

Some screenshots:

Before:
![image1](https://cdn.discordapp.com/attachments/745410459212972173/994124877567119380/unknown.png)

After:
![image](https://user-images.githubusercontent.com/47635037/177653274-c550594f-14dc-49a7-9995-b56703e7fa5e.png)

Some bots can even go lower than that. It's based on the bot trades history.