### PR TITLE
handle change of item assetid(s)

### DIFF
--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -2059,10 +2059,9 @@ export default class MyHandler extends Handler {
 
                 // Update assetid in pricelist if needed
                 if (
-                    [
-                        TradeOfferManager.ETradeOfferState['Canceled'],
-                        TradeOfferManager.ETradeOfferState['InvalidItems']
-                    ].includes(offer.state) &&
+                    ((offer.state === TradeOfferManager.ETradeOfferState['Canceled'] &&
+                        offer.data('isCanceledUnknown') === true) ||
+                        offer.state === TradeOfferManager.ETradeOfferState['InvalidItems']) &&
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                     // @ts-ignore
                     offer.tradeID

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -2049,6 +2049,14 @@ export default class MyHandler extends Handler {
                         offer.data('isFailedConfirmation', true);
                     } else {
                         offer.data('isCanceledUnknown', true);
+                        if (
+                            [
+                                TradeOfferManager.ETradeOfferState['FullSupportRollback'],
+                                TradeOfferManager.ETradeOfferState['RollbackFailed']
+                            ].includes(offer.state)
+                        ) {
+                            // Something here that handle changes of item assetid(s)
+                        }
                     }
                     MyHandler.removePolldataKeys(offer);
                 } else if (offer.state === TradeOfferManager.ETradeOfferState['InvalidItems']) {

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -2055,7 +2055,27 @@ export default class MyHandler extends Handler {
                                 TradeOfferManager.ETradeOfferState['RollbackFailed']
                             ].includes(offer.state)
                         ) {
-                            // Something here that handle changes of item assetid(s)
+                            offer.getExchangeDetails(true, (err, status, tradeInitTime, receivedItems, sentItems) => {
+                                if (err) {
+                                    return log.error(err);
+                                }
+
+                                if (Array.isArray(sentItems)) {
+                                    sentItems.forEach(item => {
+                                        const entry = this.bot.pricelist.getPriceBySkuOrAsset(item.assetid);
+
+                                        if (entry !== null && entry.id) {
+                                            const newEntry = Object.assign({}, entry);
+                                            const oldId = entry.id;
+                                            newEntry.id = item.rollback_new_assetid;
+                                            delete newEntry.name;
+                                            delete newEntry.time;
+
+                                            this.bot.pricelist.replacePriceEntry(oldId, newEntry);
+                                        }
+                                    });
+                                }
+                            });
                         }
                     }
                     MyHandler.removePolldataKeys(offer);

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -2051,8 +2051,8 @@ export default class MyHandler extends Handler {
                         offer.data('isCanceledUnknown', true);
                         if (
                             [
-                                TradeOfferManager.ETradeOfferState['FullSupportRollback'],
-                                TradeOfferManager.ETradeOfferState['RollbackFailed']
+                                TradeOfferManager.ETradeOfferState['Canceled'],
+                                TradeOfferManager.ETradeOfferState['InvalidItems']
                             ].includes(offer.state)
                         ) {
                             offer.getExchangeDetails(true, (err, status, tradeInitTime, receivedItems, sentItems) => {

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -2066,6 +2066,11 @@ export default class MyHandler extends Handler {
                     // @ts-ignore
                     offer.tradeID
                 ) {
+                    if (Object.keys(this.bot.pricelist.assetidInPricelist).length < 1) {
+                        // Check if cache is not empty
+                        return;
+                    }
+
                     offer.getExchangeDetails(true, (err, status, tradeInitTime, receivedItems, sentItems) => {
                         if (err) {
                             return log.error(err);

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -664,6 +664,23 @@ export default class Pricelist extends EventEmitter {
         });
     }
 
+    replacePriceEntry(oldId: string, newEntry: EntryData): void {
+        this.removePrice(oldId, true)
+            .then(() => {
+                this.bot.pricelist
+                    .addPrice(newEntry.id, newEntry, true)
+                    .then(() => {
+                        log.info(`Successfully replaced ${oldId} to ${newEntry.id}`);
+                    })
+                    .catch(err => {
+                        log.error(`Error replacing ${oldId} to ${newEntry.id}: `, err);
+                    });
+            })
+            .catch(err => {
+                log.error(`Error removing ${oldId} while replacing to ${newEntry.id}: `, err);
+            });
+    }
+
     private cacheAssetidInPricelist(): void {
         Object.keys(this.prices).forEach(priceKey => {
             if (Pricelist.isAssetId(priceKey)) {

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -1672,24 +1672,25 @@ export default class Trades {
         // Canceled offer, declined countered offer => new item assetid
         void this.bot.inventoryManager.getInventory
             .fetch()
+            .then(() => this.bot.handler.onTradeOfferChanged(offer, oldState, timeTakenToComplete))
             .catch(err => {
                 log.warn('Error fetching inventory: ', err);
                 log.debug('Retrying to fetch inventory in 30 seconds...');
                 clearTimeout(this.retryFetchInventoryTimeout);
-                this.retryFetchInventory();
-            })
-            .finally(() => {
-                this.bot.handler.onTradeOfferChanged(offer, oldState, timeTakenToComplete);
+                this.retryFetchInventory(offer, oldState, timeTakenToComplete);
             });
     }
 
-    private retryFetchInventory(): void {
+    private retryFetchInventory(offer: TradeOffer, oldState: number, timeTakenToComplete: number): void {
         this.retryFetchInventoryTimeout = setTimeout(() => {
-            this.bot.inventoryManager.getInventory.fetch().catch(err => {
-                log.warn('Error fetching inventory: ', err);
-                log.debug('Retrying to fetch inventory in 30 seconds...');
-                this.retryFetchInventory();
-            });
+            this.bot.inventoryManager.getInventory
+                .fetch()
+                .then(() => this.bot.handler.onTradeOfferChanged(offer, oldState, timeTakenToComplete))
+                .catch(err => {
+                    log.warn('Error fetching inventory: ', err);
+                    log.debug('Retrying to fetch inventory in 30 seconds...');
+                    this.retryFetchInventory(offer, oldState, timeTakenToComplete);
+                });
         }, 30 * 1000);
     }
 

--- a/src/types/modules/@tf2autobot/tradeoffer-manager/index.d.ts
+++ b/src/types/modules/@tf2autobot/tradeoffer-manager/index.d.ts
@@ -379,6 +379,16 @@ declare module '@tf2autobot/tradeoffer-manager' {
             ): { sku: string; isPainted: boolean } | null;
         }
 
+        export class EconItemRB extends EconItem {
+            new_assetid: string;
+
+            new_contextid: string;
+
+            rollback_new_assetid: string;
+
+            rollback_new_contextid: string;
+        }
+
         type TradeOfferItem = {
             id?: string;
             assetid: string;
@@ -476,8 +486,8 @@ declare module '@tf2autobot/tradeoffer-manager' {
                     err?: Error,
                     status?: number,
                     tradeInitTime?: Date,
-                    receivedItems?: SteamTradeOfferManager.TradeOffer[],
-                    sentItems?: SteamTradeOfferManager.TradeOffer[]
+                    receivedItems?: EconItemRB[],
+                    sentItems?: EconItemRB[]
                 ) => void
             ): void;
 

--- a/src/types/modules/@tf2autobot/tradeoffer-manager/index.d.ts
+++ b/src/types/modules/@tf2autobot/tradeoffer-manager/index.d.ts
@@ -64,18 +64,6 @@ declare module '@tf2autobot/tradeoffer-manager' {
             ) => void
         ): void;
 
-        // https://github.com/DoctorMcKay/node-steam-tradeoffer-manager/wiki/TradeOffer#getexchangedetailsgetdetailsiffailed-callback
-        getExchangeDetails(
-            getDetailsIfFailed: boolean,
-            callback: (
-                err?: Error,
-                status?: number,
-                tradeInitTime?: Date,
-                receivedItems?: SteamTradeOfferManager.TradeOffer[],
-                sentItems?: SteamTradeOfferManager.TradeOffer[]
-            ) => void
-        ): void;
-
         doPoll(): void;
 
         setCookies(cookies: string[], callback?: (err?: Error) => void): void;
@@ -480,6 +468,18 @@ declare module '@tf2autobot/tradeoffer-manager' {
              * @param callback - Function to call when done
              */
             cancel(callback?: (err: Error | null) => void): void;
+
+            // https://github.com/DoctorMcKay/node-steam-tradeoffer-manager/wiki/TradeOffer#getexchangedetailsgetdetailsiffailed-callback
+            getExchangeDetails(
+                getDetailsIfFailed: boolean,
+                callback: (
+                    err?: Error,
+                    status?: number,
+                    tradeInitTime?: Date,
+                    receivedItems?: SteamTradeOfferManager.TradeOffer[],
+                    sentItems?: SteamTradeOfferManager.TradeOffer[]
+                ) => void
+            ): void;
 
             // Custom function added to prototype
             log(level: string, message: string, ...meta: any[]);

--- a/src/types/modules/@tf2autobot/tradeoffer-manager/index.d.ts
+++ b/src/types/modules/@tf2autobot/tradeoffer-manager/index.d.ts
@@ -64,6 +64,18 @@ declare module '@tf2autobot/tradeoffer-manager' {
             ) => void
         ): void;
 
+        // https://github.com/DoctorMcKay/node-steam-tradeoffer-manager/wiki/TradeOffer#getexchangedetailsgetdetailsiffailed-callback
+        getExchangeDetails(
+            getDetailsIfFailed: boolean,
+            callback: (
+                err?: Error,
+                status?: number,
+                tradeInitTime?: Date,
+                receivedItems?: SteamTradeOfferManager.TradeOffer[],
+                sentItems?: SteamTradeOfferManager.TradeOffer[]
+            ) => void
+        ): void;
+
         doPoll(): void;
 
         setCookies(cookies: string[], callback?: (err?: Error) => void): void;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/47635037/177787050-7ed1deb5-05ec-4e28-9d03-29bc85c8b3ea.png)
Credit: @ZeusJunior

Btw, I am not so sure how to continue this. Anyone that knows, feel free to contribute.
The idea is:
- If an offer was rolled back:
   - update the existing assetid in pricelist to the new one.