### PR TITLE
🎨 Fix pure stock

### DIFF
--- a/src/lib/tools/pure.ts
+++ b/src/lib/tools/pure.ts
@@ -25,7 +25,7 @@ export function stock(bot: Bot): string[] {
                       }${pure.rec > 0 ? `${pure.ref > 0 ? ' ' : ''}${pure.rec} rec${pure.scrap > 0 ? ',' : ''}` : ''}${
                           pure.scrap > 0 ? `${pure.ref > 0 || pure.rec > 0 ? ' ' : ''}${pure.scrap} scrap` : ''
                       })`
-                    : ''
+                    : ' ref'
             }`
         }
     ];


### PR DESCRIPTION
Fixes:
![image](https://user-images.githubusercontent.com/47635037/178418364-6f3acf03-d92a-442b-8cf8-03b65902ed2f.png)

Will show `1 key, 0 ref` or `0 ref` instead of just `0`.