### PR TITLE
🔨 fix not handle Discord webhook price update rate limit

### DIFF
--- a/src/lib/DiscordWebhook/utils.ts
+++ b/src/lib/DiscordWebhook/utils.ts
@@ -3,7 +3,7 @@ import axios, { AxiosError } from 'axios';
 import { Webhook } from './interfaces';
 import Bot from '../../classes/Bot';
 import log from '../logger';
-import filterAxiosError from '@tf2autobot/filter-axios-error';
+import filterAxiosError, { ErrorFiltered } from '@tf2autobot/filter-axios-error';
 
 export function getPartnerDetails(offer: TradeOffer, bot: Bot): Promise<{ personaName: string; avatarFull: any }> {
     return new Promise(resolve => {
@@ -73,10 +73,6 @@ export function sendWebhook(url: string, webhook: Webhook, event: string, i?: nu
 }
 
 export interface WebhookError {
-    err: {
-        message: string;
-        status: number;
-        data: Record<string, any>;
-    };
+    err: ErrorFiltered;
     webhook: Webhook;
 }

--- a/src/lib/DiscordWebhook/utils.ts
+++ b/src/lib/DiscordWebhook/utils.ts
@@ -3,6 +3,7 @@ import axios, { AxiosError } from 'axios';
 import { Webhook } from './interfaces';
 import Bot from '../../classes/Bot';
 import log from '../logger';
+import filterAxiosError from '@tf2autobot/filter-axios-error';
 
 export function getPartnerDetails(offer: TradeOffer, bot: Bot): Promise<{ personaName: string; avatarFull: any }> {
     return new Promise(resolve => {
@@ -66,7 +67,16 @@ export function sendWebhook(url: string, webhook: Webhook, event: string, i?: nu
                 resolve();
             })
             .catch((err: AxiosError) => {
-                reject({ err: err.response.data, webhook });
+                reject({ err: filterAxiosError(err), webhook });
             });
     });
+}
+
+export interface WebhookError {
+    err: {
+        message: string;
+        status: number;
+        data: Record<string, any>;
+    };
+    webhook: Webhook;
 }


### PR DESCRIPTION
This issue was introduced on [v4.14.0](https://github.com/TF2Autobot/tf2autobot/releases/tag/v4.14.0) when upgrading the Discord Webhook requests to use Axios.
![image](https://user-images.githubusercontent.com/47635037/179348693-82ba1af5-8b0c-4d0c-8373-9bc59a50d9f4.png)
