### PR TITLE
🔨 add missing craftNumber parsing

### DIFF
--- a/src/classes/Inventory.ts
+++ b/src/classes/Inventory.ts
@@ -411,6 +411,8 @@ export default class Inventory {
         const isNormalizeStrangeAsSecondQuality = isAdmin ? false : bot.options.normalize.strangeAsSecondQuality[which];
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const isNormalizePainted = isAdmin ? false : bot.options.normalize.painted[which];
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const isNormalizeCraftNumber = isAdmin ? false : bot.options.normalize.craftNumber[which];
 
         for (let i = 0; i < itemsCount; i++) {
             const getSku = items[i].getSKU(
@@ -418,6 +420,7 @@ export default class Inventory {
                 isNormalizeFestivized,
                 isNormalizeStrangeAsSecondQuality,
                 isNormalizePainted,
+                isNormalizeCraftNumber,
                 this.paintedOptions
             );
 

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -255,6 +255,10 @@ export const DEFAULTS: JsonOptions = {
             our: true,
             their: true,
             amountIncludeNonPainted: false
+        },
+        craftNumber: {
+            our: false,
+            their: false
         }
     },
 
@@ -1318,6 +1322,7 @@ interface Normalize {
     festivized?: NormalizeFestivized;
     strangeAsSecondQuality?: NormalizeStrange;
     painted?: NormalizePainted;
+    craftNumber?: NormalizeOurOrTheir;
 }
 
 interface NormalizeOurOrTheir {

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -959,9 +959,22 @@ export const optionsSchema: jsonschema.Schema = {
                     },
                     required: ['our', 'their', 'amountIncludeNonPainted'],
                     additionalProperties: false
+                },
+                craftNumber: {
+                    type: 'object',
+                    properties: {
+                        our: {
+                            type: 'boolean'
+                        },
+                        their: {
+                            type: 'boolean'
+                        }
+                    },
+                    required: ['our', 'their'],
+                    additionalProperties: false
                 }
             },
-            required: ['festivized', 'strangeAsSecondQuality', 'painted'],
+            required: ['festivized', 'strangeAsSecondQuality', 'painted', 'craftNumber'],
             additionalProperties: false
         },
         details: {

--- a/src/types/modules/@tf2autobot/tradeoffer-manager/index.d.ts
+++ b/src/types/modules/@tf2autobot/tradeoffer-manager/index.d.ts
@@ -374,6 +374,7 @@ declare module '@tf2autobot/tradeoffer-manager' {
                 normalizeFestivizedItems: boolean,
                 normalizeStrangeAsSecondQuality: boolean,
                 normalizePainted: boolean,
+                normalizeCraftNumber: boolean,
                 paintsInOptions: string[]
             ): { sku: string; isPainted: boolean } | null;
         }


### PR DESCRIPTION
New options:
- `normalize.craftNumber.our` (default is `false`)
- `normalize.craftNumber.their` (default is `false`)
