### PR TITLE
Update commands

### DIFF
--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -104,222 +104,163 @@ export default class Commands {
             return this.bot.sendMessage(steamID, "⛔ Don't spam");
         }
 
-        const ignoreWords: { [type: string]: string[] } = {
-            startsWith: [
-                'I',
-                '❌',
-                'Hi',
-                '🙋🏻‍♀️Hi',
-                '⚠',
-                '⚠️',
-                '✅',
-                '⌛',
-                '💲',
-                '📜',
-                '🛒',
-                '💰',
-                'Here',
-                'The',
-                'Please',
-                'You',
-                '/quote',
-                '/pre',
-                '/pre2',
-                '/me',
-                '/code',
-                'Oh',
-                'Success!',
-                'Hey',
-                'Unfortunately',
-                '==',
-                '💬',
-                '⇌',
-                'Command',
-                'Hello',
-                '✋ Hold on',
-                'Hold on',
-                'Sending',
-                'Checking', // for "Checking out..." phrase from gladiator
-                '👋 Welcome',
-                'Welcome',
-                'To',
-                '🔰',
-                'My',
-                'Owner',
-                'Bot',
-                'Those',
-                '👨🏼‍💻',
-                '🔶',
-                'Buying',
-                '🔷',
-                'Selling',
-                '📥',
-                'Stock',
-                'Thank',
-                'Unknown'
-            ],
-            endsWith: ['cart.', 'checkout.', '✅']
-        };
+        if (message.startsWith('!')) {
+            if (command === 'help') {
+                void this.help.helpCommand(steamID);
+            } else if (command === 'how2trade') {
+                this.help.howToTradeCommand(steamID);
+            } else if (['price', 'pc'].includes(command)) {
+                this.priceCommand(steamID, message);
+            } else if (['buy', 'b', 'sell', 's'].includes(command)) {
+                this.buyOrSellCommand(steamID, message, command as Instant);
+            } else if (command === 'buycart') {
+                this.buyCartCommand(steamID, message);
+            } else if (command === 'sellcart') {
+                this.sellCartCommand(steamID, message);
+            } else if (command === 'cart') {
+                this.cartCommand(steamID);
+            } else if (command === 'clearcart') {
+                this.clearCartCommand(steamID);
+            } else if (command === 'checkout') {
+                this.checkoutCommand(steamID);
+            } else if (command === 'cancel') {
+                this.cancelCommand(steamID);
+            } else if (command === 'queue') {
+                this.queueCommand(steamID);
+            } else if (['time', 'uptime', 'pure', 'rate', 'owner', 'discord', 'stock'].includes(command)) {
+                if (command === 'stock') {
+                    return this.misc.miscCommand(steamID, command as Misc, message);
+                }
+                this.misc.miscCommand(steamID, command as Misc);
+            } else if (command === 'paints' && isAdmin) {
+                this.misc.paintsCommand(steamID);
+            } else if (command === 'more') {
+                this.help.moreCommand(steamID);
+            } else if (command === 'autokeys') {
+                this.manager.autokeysCommand(steamID);
+            } else if (command === 'message') {
+                this.message.message(steamID, message);
+            } else if (['craftweapon', 'craftweapons', 'uncraftweapon', 'uncraftweapons'].includes(command)) {
+                void this.misc.weaponCommand(
+                    steamID,
+                    command === 'craftweapons'
+                        ? 'craftweapon'
+                        : command === 'uncraftweapons'
+                        ? 'uncraftweapon'
+                        : (command as CraftUncraft)
+                );
+            } else if (['deposit', 'd'].includes(command) && isAdmin) {
+                void this.depositCommand(steamID, message);
+            } else if (['withdraw', 'w'].includes(command) && isAdmin) {
+                this.withdrawCommand(steamID, message);
+            } else if (command === 'withdrawmptf' && isAdmin) {
+                void this.withdrawMptfCommand(steamID, message);
+            } else if (command === 'add' && isAdmin) {
+                await this.pManager.addCommand(steamID, message);
+            } else if (command === 'addbulk' && isAdmin) {
+                void this.pManager.addbulkCommand(steamID, message);
+            } else if (command === 'update' && isAdmin) {
+                void this.pManager.updateCommand(steamID, message);
+            } else if (command === 'updatebulk' && isAdmin) {
+                void this.pManager.updatebulkCommand(steamID, message);
+            } else if (command === 'remove' && isAdmin) {
+                void this.pManager.removeCommand(steamID, message);
+            } else if (command === 'removebulk' && isAdmin) {
+                this.pManager.removebulkCommand(steamID, message);
+            } else if (command === 'get' && isAdmin) {
+                this.pManager.getCommand(steamID, message);
+            } else if (command === 'getall' && isAdmin) {
+                void this.pManager.getAllCommand(steamID, message);
+            } else if (command === 'ppu' && isAdmin) {
+                void this.pManager.partialPriceUpdateCommand(steamID, message);
+            } else if (['getslots', 'listings'].includes(command) && isAdmin) {
+                void this.pManager.getSlotsCommand(steamID);
+            } else if (command === 'autoadd' && isAdmin) {
+                this.pManager.autoAddCommand(steamID, message);
+            } else if (command === 'stopautoadd' && isAdmin) {
+                this.pManager.stopAutoAddCommand();
+            } else if (['expand', 'delete', 'use'].includes(command) && isAdmin) {
+                this.manager.TF2GCCommand(steamID, message, command as TF2GC);
+            } else if (['name', 'avatar'].includes(command) && isAdmin) {
+                this.manager.nameAvatarCommand(steamID, message, command as NameAvatar);
+            } else if (['block', 'unblock'].includes(command) && isAdmin) {
+                this.manager.blockUnblockCommand(steamID, message, command as BlockUnblock);
+            } else if (['blockedlist', 'blocklist', 'blist'].includes(command) && isAdmin) {
+                void this.manager.blockedListCommand(steamID);
+            } else if (command === 'clearfriends' && isAdmin) {
+                this.manager.clearFriendsCommand(steamID);
+            } else if (command === 'stop' && isAdmin) {
+                this.manager.stopCommand(steamID);
+            } else if (command === 'halt' && isAdmin) {
+                await this.manager.haltCommand(steamID);
+            } else if (command === 'unhalt' && isAdmin) {
+                await this.manager.unhaltCommand(steamID);
+            } else if (command === 'haltstatus' && isAdmin) {
+                this.manager.haltStatusCommand(steamID);
+            } else if (command === 'restart' && isAdmin) {
+                this.manager.restartCommand(steamID);
+            } else if (command === 'updaterepo' && isAdmin) {
+                this.manager.updaterepoCommand(steamID);
+            } else if (command === 'refreshautokeys' && isAdmin) {
+                this.manager.refreshAutokeysCommand(steamID);
+            } else if (command === 'refreshlist' && isAdmin) {
+                this.manager.refreshListingsCommand(steamID);
+            } else if (command === 'stats' && isAdmin) {
+                void this.status.statsCommand(steamID);
+            } else if (command === 'statsdw' && isAdmin) {
+                this.status.statsDWCommand(steamID);
+            } else if (command === 'itemstats' && (isAdmin || isWhitelisted)) {
+                void this.status.itemStatsCommand(steamID, message);
+            } else if (command === 'inventory' && isAdmin) {
+                this.status.inventoryCommand(steamID);
+            } else if (command === 'version' && (isAdmin || isWhitelisted)) {
+                this.status.versionCommand(steamID);
+            } else if (command === 'trades' && isAdmin) {
+                this.review.tradesCommand(steamID);
+            } else if (command === 'trade' && isAdmin) {
+                this.review.tradeCommand(steamID, message);
+            } else if (['accepttrade', 'accept', 'declinetrade', 'decline'].includes(command) && isAdmin) {
+                void this.review.actionOnTradeCommand(steamID, message, command as ActionOnTrade);
+            } else if (['faccept', 'fdecline'].includes(command) && isAdmin) {
+                void this.review.forceAction(steamID, message, command as ForceAction);
+            } else if (command === 'offerinfo' && isAdmin) {
+                this.review.offerInfo(steamID, message);
+            } else if (command === 'pricecheck' && isAdmin) {
+                this.request.pricecheckCommand(steamID, message);
+            } else if (command === 'pricecheckall' && isAdmin) {
+                void this.request.pricecheckAllCommand(steamID);
+            } else if (command === 'check' && isAdmin) {
+                void this.request.checkCommand(steamID, message);
+            } else if (command === 'find' && isAdmin) {
+                void this.pManager.findCommand(steamID, message);
+            } else if (command === 'options' && isAdmin) {
+                void this.opt.optionsCommand(steamID, message);
+            } else if (command === 'config' && isAdmin) {
+                this.opt.updateOptionsCommand(steamID, message);
+            } else if (command === 'cleararray' && isAdmin) {
+                this.opt.clearArrayCommand(steamID, message);
+            } else if (command === 'donatebptf' && isAdmin) {
+                this.donateBPTFCommand(steamID, message);
+            } else if (command === 'donatenow' && isAdmin) {
+                this.donateNowCommand(steamID);
+            } else if (command === 'donatecart' && isAdmin) {
+                this.donateCartCommand(steamID);
+            } else if (command === 'premium' && isAdmin) {
+                this.buyBPTFPremiumCommand(steamID, message);
+            } else if (command === 'sku' && isAdmin) {
+                this.getSKU(steamID, message);
+            } else if (command === 'refreshschema' && isAdmin) {
+                this.manager.refreshSchema(steamID);
+            } else if (command === 'crafttoken' && isAdmin) {
+                this.crafting.craftTokenCommand(steamID, message);
+            } else {
+                const custom = this.bot.options.customMessage.commandNotFound;
 
-        if (command === 'help') {
-            void this.help.helpCommand(steamID);
-        } else if (command === 'how2trade') {
-            this.help.howToTradeCommand(steamID);
-        } else if (['price', 'pc'].includes(command)) {
-            this.priceCommand(steamID, message);
-        } else if (['buy', 'b', 'sell', 's'].includes(command)) {
-            this.buyOrSellCommand(steamID, message, command as Instant);
-        } else if (command === 'buycart') {
-            this.buyCartCommand(steamID, message);
-        } else if (command === 'sellcart') {
-            this.sellCartCommand(steamID, message);
-        } else if (command === 'cart') {
-            this.cartCommand(steamID);
-        } else if (command === 'clearcart') {
-            this.clearCartCommand(steamID);
-        } else if (command === 'checkout') {
-            this.checkoutCommand(steamID);
-        } else if (command === 'cancel') {
-            this.cancelCommand(steamID);
-        } else if (command === 'queue') {
-            this.queueCommand(steamID);
-        } else if (['time', 'uptime', 'pure', 'rate', 'owner', 'discord', 'stock'].includes(command)) {
-            if (command === 'stock') {
-                return this.misc.miscCommand(steamID, command as Misc, message);
+                this.bot.sendMessage(
+                    steamID,
+                    custom ? custom.replace('%command%', command) : `❌ Command "!${command}" not found!`
+                );
             }
-            this.misc.miscCommand(steamID, command as Misc);
-        } else if (command === 'paints' && isAdmin) {
-            this.misc.paintsCommand(steamID);
-        } else if (command === 'more') {
-            this.help.moreCommand(steamID);
-        } else if (command === 'autokeys') {
-            this.manager.autokeysCommand(steamID);
-        } else if (command === 'message') {
-            this.message.message(steamID, message);
-        } else if (['craftweapon', 'craftweapons', 'uncraftweapon', 'uncraftweapons'].includes(command)) {
-            void this.misc.weaponCommand(
-                steamID,
-                command === 'craftweapons'
-                    ? 'craftweapon'
-                    : command === 'uncraftweapons'
-                    ? 'uncraftweapon'
-                    : (command as CraftUncraft)
-            );
-        } else if (['deposit', 'd'].includes(command) && isAdmin) {
-            void this.depositCommand(steamID, message);
-        } else if (['withdraw', 'w'].includes(command) && isAdmin) {
-            this.withdrawCommand(steamID, message);
-        } else if (command === 'withdrawmptf' && isAdmin) {
-            void this.withdrawMptfCommand(steamID, message);
-        } else if (command === 'add' && isAdmin) {
-            await this.pManager.addCommand(steamID, message);
-        } else if (command === 'addbulk' && isAdmin) {
-            void this.pManager.addbulkCommand(steamID, message);
-        } else if (command === 'update' && isAdmin) {
-            void this.pManager.updateCommand(steamID, message);
-        } else if (command === 'updatebulk' && isAdmin) {
-            void this.pManager.updatebulkCommand(steamID, message);
-        } else if (command === 'remove' && isAdmin) {
-            void this.pManager.removeCommand(steamID, message);
-        } else if (command === 'removebulk' && isAdmin) {
-            this.pManager.removebulkCommand(steamID, message);
-        } else if (command === 'get' && isAdmin) {
-            this.pManager.getCommand(steamID, message);
-        } else if (command === 'getall' && isAdmin) {
-            void this.pManager.getAllCommand(steamID, message);
-        } else if (command === 'ppu' && isAdmin) {
-            void this.pManager.partialPriceUpdateCommand(steamID, message);
-        } else if (['getslots', 'listings'].includes(command) && isAdmin) {
-            void this.pManager.getSlotsCommand(steamID);
-        } else if (command === 'autoadd' && isAdmin) {
-            this.pManager.autoAddCommand(steamID, message);
-        } else if (command === 'stopautoadd' && isAdmin) {
-            this.pManager.stopAutoAddCommand();
-        } else if (['expand', 'delete', 'use'].includes(command) && isAdmin) {
-            this.manager.TF2GCCommand(steamID, message, command as TF2GC);
-        } else if (['name', 'avatar'].includes(command) && isAdmin) {
-            this.manager.nameAvatarCommand(steamID, message, command as NameAvatar);
-        } else if (['block', 'unblock'].includes(command) && isAdmin) {
-            this.manager.blockUnblockCommand(steamID, message, command as BlockUnblock);
-        } else if (['blockedlist', 'blocklist', 'blist'].includes(command) && isAdmin) {
-            void this.manager.blockedListCommand(steamID);
-        } else if (command === 'clearfriends' && isAdmin) {
-            this.manager.clearFriendsCommand(steamID);
-        } else if (command === 'stop' && isAdmin) {
-            this.manager.stopCommand(steamID);
-        } else if (command === 'halt' && isAdmin) {
-            await this.manager.haltCommand(steamID);
-        } else if (command === 'unhalt' && isAdmin) {
-            await this.manager.unhaltCommand(steamID);
-        } else if (command === 'haltstatus' && isAdmin) {
-            this.manager.haltStatusCommand(steamID);
-        } else if (command === 'restart' && isAdmin) {
-            this.manager.restartCommand(steamID);
-        } else if (command === 'updaterepo' && isAdmin) {
-            this.manager.updaterepoCommand(steamID);
-        } else if (command === 'refreshautokeys' && isAdmin) {
-            this.manager.refreshAutokeysCommand(steamID);
-        } else if (command === 'refreshlist' && isAdmin) {
-            this.manager.refreshListingsCommand(steamID);
-        } else if (command === 'stats' && isAdmin) {
-            void this.status.statsCommand(steamID);
-        } else if (command === 'statsdw' && isAdmin) {
-            this.status.statsDWCommand(steamID);
-        } else if (command === 'itemstats' && (isAdmin || isWhitelisted)) {
-            void this.status.itemStatsCommand(steamID, message);
-        } else if (command === 'inventory' && isAdmin) {
-            this.status.inventoryCommand(steamID);
-        } else if (command === 'version' && (isAdmin || isWhitelisted)) {
-            this.status.versionCommand(steamID);
-        } else if (command === 'trades' && isAdmin) {
-            this.review.tradesCommand(steamID);
-        } else if (command === 'trade' && isAdmin) {
-            this.review.tradeCommand(steamID, message);
-        } else if (['accepttrade', 'accept', 'declinetrade', 'decline'].includes(command) && isAdmin) {
-            void this.review.actionOnTradeCommand(steamID, message, command as ActionOnTrade);
-        } else if (['faccept', 'fdecline'].includes(command) && isAdmin) {
-            void this.review.forceAction(steamID, message, command as ForceAction);
-        } else if (command === 'offerinfo' && isAdmin) {
-            this.review.offerInfo(steamID, message);
-        } else if (command === 'pricecheck' && isAdmin) {
-            this.request.pricecheckCommand(steamID, message);
-        } else if (command === 'pricecheckall' && isAdmin) {
-            void this.request.pricecheckAllCommand(steamID);
-        } else if (command === 'check' && isAdmin) {
-            void this.request.checkCommand(steamID, message);
-        } else if (command === 'find' && isAdmin) {
-            void this.pManager.findCommand(steamID, message);
-        } else if (command === 'options' && isAdmin) {
-            void this.opt.optionsCommand(steamID, message);
-        } else if (command === 'config' && isAdmin) {
-            this.opt.updateOptionsCommand(steamID, message);
-        } else if (command === 'cleararray' && isAdmin) {
-            this.opt.clearArrayCommand(steamID, message);
-        } else if (command === 'donatebptf' && isAdmin) {
-            this.donateBPTFCommand(steamID, message);
-        } else if (command === 'donatenow' && isAdmin) {
-            this.donateNowCommand(steamID);
-        } else if (command === 'donatecart' && isAdmin) {
-            this.donateCartCommand(steamID);
-        } else if (command === 'premium' && isAdmin) {
-            this.buyBPTFPremiumCommand(steamID, message);
-        } else if (command === 'sku' && isAdmin) {
-            this.getSKU(steamID, message);
-        } else if (command === 'refreshschema' && isAdmin) {
-            this.manager.refreshSchema(steamID);
-        } else if (command === 'crafttoken' && isAdmin) {
-            this.crafting.craftTokenCommand(steamID, message);
-        } else if (
-            ignoreWords.startsWith.some(word => message.startsWith(word)) ||
-            ignoreWords.endsWith.some(word => message.endsWith(word))
-        ) {
-            return;
-        } else {
-            const custom = this.bot.options.customMessage.iDontKnowWhatYouMean;
-            this.bot.sendMessage(
-                steamID,
-                custom ? custom : '❌ I don\'t know what you mean, please type "!help" for all of my commands!'
-            );
         }
     }
 

--- a/src/classes/Commands/sub-classes/Options.ts
+++ b/src/classes/Commands/sub-classes/Options.ts
@@ -395,7 +395,7 @@ export default class OptionsCommands {
                             customMessage: {
                                 sendOffer: webhook.sendOffer,
                                 welcome: webhook.welcome,
-                                iDontKnowWhatYouMean: webhook.iDontKnowWhatYouMean,
+                                commandNotFound: webhook.commandNotFound,
                                 success: webhook.success,
                                 successEscrow: webhook.successEscrow
                             }

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -540,7 +540,7 @@ export const DEFAULTS: JsonOptions = {
         sendOffer: '',
         counterOffer: '',
         welcome: '',
-        iDontKnowWhatYouMean: '',
+        commandNotFound: '',
         success: '',
         successEscrow: '',
         halted: '',
@@ -1604,7 +1604,7 @@ interface CustomMessage {
     sendOffer?: string;
     counterOffer?: string;
     welcome?: string;
-    iDontKnowWhatYouMean?: string;
+    commandNotFound?: string;
     success?: string;
     successEscrow?: string;
     halted?: string;
@@ -2292,6 +2292,17 @@ function replaceOldProperties(options: Options): boolean {
         isChanged = true;
     }
     /*eslint-enable */
+
+    // <=v4.16.2 -> v5.0.0
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    if (options.customMessage?.iDontKnowWhatYouMean !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //@ts-ignore
+        delete options.customMessage.iDontKnowWhatYouMean;
+        options.customMessage['commandNotFound'] = '';
+        isChanged = true;
+    }
 
     return isChanged;
 }

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -1659,7 +1659,7 @@ export const optionsSchema: jsonschema.Schema = {
                 welcome: {
                     type: 'string'
                 },
-                iDontKnowWhatYouMean: {
+                commandNotFound: {
                     type: 'string'
                 },
                 success: {
@@ -1783,7 +1783,7 @@ export const optionsSchema: jsonschema.Schema = {
                 'sendOffer',
                 'counterOffer',
                 'welcome',
-                'iDontKnowWhatYouMean',
+                'commandNotFound',
                 'success',
                 'successEscrow',
                 'decline',


### PR DESCRIPTION
Only respond to message starting with `!`
   - No more `❌ I don't know what you mean` 
   - 🔄 replace `customMessage.iDontKnowWhatYouMean` -> `customMessage.commandNotFound`
   - Optional parameter: `%command%`
   - Default: `❌ Command "!%command%" not found!`


---
Later:
- `!help` command will link to https://wiki.autobot.tf/Commands-Admin for admin and https://wiki.autobot.tf/Commands-Trade-Partner for trade partner.
- Will think more...