### PR TITLE
✅ properly handle inventory fetch

### DIFF
--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -1714,8 +1714,6 @@ export default class Trades {
                 })
                 .catch(err => {
                     log.warn('Error fetching inventory: ', err);
-                    log.debug('Retrying to fetch inventory in 30 seconds...');
-                    this.calledRetryFetchFreq++;
 
                     if (this.calledRetryFetchFreq > 3) {
                         // If more than 3 times failed, then just proceed with an outdated inventory
@@ -1734,6 +1732,8 @@ export default class Trades {
                         return;
                     }
 
+                    log.debug('Retrying to fetch inventory in 30 seconds...');
+                    this.calledRetryFetchFreq++;
                     this.retryFetchInventory();
                 });
         }, 30 * 1000);

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -1660,9 +1660,12 @@ export default class Trades {
 
         if (
             offer.state === TradeOfferManager.ETradeOfferState['Active'] ||
-            offer.state === TradeOfferManager.ETradeOfferState['CreatedNeedsConfirmation']
+            offer.state === TradeOfferManager.ETradeOfferState['CreatedNeedsConfirmation'] ||
+            offer.state === TradeOfferManager.ETradeOfferState['Countered'] ||
+            (oldState === TradeOfferManager.ETradeOfferState['Countered'] &&
+                offer.state === TradeOfferManager.ETradeOfferState['Declined'])
         ) {
-            // Offer is active, no need to fetch
+            // Offer is active, or countered, or declined countered, no need to fetch
             // Do nothing
         } else {
             this.offerChangedAcc.push({ offer, oldState, timeTakenToComplete });
@@ -1672,7 +1675,7 @@ export default class Trades {
                 // Only call `fetch` if accumulated offerChanged is less than or equal to 1
                 // Prevent never ending "The request is a duplicate and the action has already occurred in the past, ignored this time"
 
-                // Canceled offer, declined countered offer => new item assetid
+                // Accepted, Invalid trade (possible) => new item assetid
                 log.debug('Fetching our inventory...');
                 return void this.bot.inventoryManager.getInventory
                     .fetch()

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -1659,13 +1659,15 @@ export default class Trades {
         this.bot.client.gamesPlayed([]);
 
         this.offerChangedAcc.push({ offer, oldState, timeTakenToComplete });
+        log.debug('Accumulated offerChanged: ', this.offerChangedAcc.length);
 
         if (this.offerChangedAcc.length <= 1) {
             // Only call `fetch` if accumulated offerChanged is less than or equal to 1
             // Prevent never ending "The request is a duplicate and the action has already occurred in the pass, ignored this time"
 
             // Canceled offer, declined countered offer => new item assetid
-            void this.bot.inventoryManager.getInventory
+            log.debug('Fetching our inventory...');
+            return void this.bot.inventoryManager.getInventory
                 .fetch()
                 .then(() => {
                     if (this.offerChangedAcc.length > 0) {
@@ -1688,6 +1690,8 @@ export default class Trades {
                     }
                 });
         }
+
+        log.debug('Not fetching inventory this time...');
     }
 
     private retryFetchInventory(): void {

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -48,6 +48,10 @@ export default class Trades {
 
     private retryFetchInventoryTimeout: NodeJS.Timeout;
 
+    private calledRetryFetchFreq = 0;
+
+    private offerChangedAcc: { offer: TradeOffer; oldState: number; timeTakenToComplete: number }[] = [];
+
     constructor(private readonly bot: Bot) {
         this.bot = bot;
     }
@@ -1654,27 +1658,79 @@ export default class Trades {
         // https://github.com/TF2Autobot/tf2autobot/issues/527
         this.bot.client.gamesPlayed([]);
 
-        // Canceled offer, declined countered offer => new item assetid
-        void this.bot.inventoryManager.getInventory
-            .fetch()
-            .then(() => this.bot.handler.onTradeOfferChanged(offer, oldState, timeTakenToComplete))
-            .catch(err => {
-                log.warn('Error fetching inventory: ', err);
-                log.debug('Retrying to fetch inventory in 30 seconds...');
-                clearTimeout(this.retryFetchInventoryTimeout);
-                this.retryFetchInventory(offer, oldState, timeTakenToComplete);
-            });
-    }
+        this.offerChangedAcc.push({ offer, oldState, timeTakenToComplete });
 
-    private retryFetchInventory(offer: TradeOffer, oldState: number, timeTakenToComplete: number): void {
-        this.retryFetchInventoryTimeout = setTimeout(() => {
-            this.bot.inventoryManager.getInventory
+        if (this.offerChangedAcc.length <= 1) {
+            // Only call `fetch` if accumulated offerChanged is less than or equal to 1
+            // Prevent never ending "The request is a duplicate and the action has already occurred in the pass, ignored this time"
+
+            // Canceled offer, declined countered offer => new item assetid
+            void this.bot.inventoryManager.getInventory
                 .fetch()
-                .then(() => this.bot.handler.onTradeOfferChanged(offer, oldState, timeTakenToComplete))
+                .then(() => {
+                    if (this.offerChangedAcc.length > 0) {
+                        this.offerChangedAcc.forEach(el => {
+                            this.bot.handler.onTradeOfferChanged(el.offer, el.oldState, el.timeTakenToComplete);
+                        });
+
+                        // Reset to empty array
+                        this.offerChangedAcc.length = 0;
+                    }
+                })
                 .catch(err => {
                     log.warn('Error fetching inventory: ', err);
                     log.debug('Retrying to fetch inventory in 30 seconds...');
-                    this.retryFetchInventory(offer, oldState, timeTakenToComplete);
+                    this.calledRetryFetchFreq++;
+
+                    if (this.calledRetryFetchFreq === 1) {
+                        // Only call this once (before reset)
+                        this.retryFetchInventory();
+                    }
+                });
+        }
+    }
+
+    private retryFetchInventory(): void {
+        clearTimeout(this.retryFetchInventoryTimeout);
+        this.retryFetchInventoryTimeout = setTimeout(() => {
+            this.bot.inventoryManager.getInventory
+                .fetch()
+                .then(() => {
+                    if (this.offerChangedAcc.length > 0) {
+                        this.offerChangedAcc.forEach(el => {
+                            this.bot.handler.onTradeOfferChanged(el.offer, el.oldState, el.timeTakenToComplete);
+                        });
+
+                        // Reset to empty array
+                        this.offerChangedAcc.length = 0;
+                    }
+
+                    // Reset to 0
+                    this.calledRetryFetchFreq = 0;
+                })
+                .catch(err => {
+                    log.warn('Error fetching inventory: ', err);
+                    log.debug('Retrying to fetch inventory in 30 seconds...');
+                    this.calledRetryFetchFreq++;
+
+                    if (this.calledRetryFetchFreq > 3) {
+                        // If more than 3 times failed, then just proceed with an outdated inventory
+                        if (this.offerChangedAcc.length > 0) {
+                            this.offerChangedAcc.forEach(el => {
+                                this.bot.handler.onTradeOfferChanged(el.offer, el.oldState, el.timeTakenToComplete);
+                            });
+
+                            // Reset to empty array
+                            this.offerChangedAcc.length = 0;
+                        }
+
+                        // Reset to 0
+                        this.calledRetryFetchFreq = 0;
+
+                        return;
+                    }
+
+                    this.retryFetchInventory();
                 });
         }, 30 * 1000);
     }

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -1663,7 +1663,7 @@ export default class Trades {
 
         if (this.offerChangedAcc.length <= 1) {
             // Only call `fetch` if accumulated offerChanged is less than or equal to 1
-            // Prevent never ending "The request is a duplicate and the action has already occurred in the pass, ignored this time"
+            // Prevent never ending "The request is a duplicate and the action has already occurred in the past, ignored this time"
 
             // Canceled offer, declined countered offer => new item assetid
             log.debug('Fetching our inventory...');


### PR DESCRIPTION
Prevent never-ending "The request is a duplicate and the action has already occurred in the past, ignored this time" on fetching inventory when the bot received and processed a lot of offers in a short period.

![image](https://user-images.githubusercontent.com/47635037/179428628-2455a2e0-1ddf-4745-ab52-e9fbb359aa28.png)