### PR TITLE
💯 Allow Discord bot to chat with non-admin

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -1239,9 +1239,6 @@ export default class Bot {
     }
 
     sendMessage(steamID: SteamID | string, message: string): void {
-        const steamID64 = steamID.toString();
-        const friend = this.friends.getFriend(steamID64);
-
         if (steamID instanceof SteamID && steamID.redirectAnswerTo) {
             const origMessage = steamID.redirectAnswerTo;
             if (origMessage instanceof DiscordMessage) {
@@ -1251,6 +1248,9 @@ export default class Bot {
             }
             return;
         }
+
+        const steamID64 = steamID.toString();
+        const friend = this.friends.getFriend(steamID64);
 
         if (!friend) {
             // If not friend, we send message with chatMessage

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -97,12 +97,15 @@ export default class Commands {
         const command = CommandParser.getCommand(message.toLowerCase());
         const isAdmin = this.bot.isAdmin(steamID);
         const isWhitelisted = this.bot.isWhitelisted(steamID);
+        const isInvalidType = steamID.type === 0;
 
         const checkMessage = message.split(' ').filter(word => word.includes(`!${command}`)).length;
 
         if (checkMessage > 1 && !isAdmin) {
             return this.bot.sendMessage(steamID, "⛔ Don't spam");
         }
+
+        log.debug('Read processMessage');
 
         if (message.startsWith('!')) {
             if (command === 'help') {
@@ -112,34 +115,63 @@ export default class Commands {
             } else if (['price', 'pc'].includes(command)) {
                 this.priceCommand(steamID, message);
             } else if (['buy', 'b', 'sell', 's'].includes(command)) {
+                if (isInvalidType) {
+                    return this.bot.sendMessage(steamID, '❌ Command not available.');
+                }
                 this.buyOrSellCommand(steamID, message, command as Instant);
             } else if (command === 'buycart') {
+                if (isInvalidType) {
+                    return this.bot.sendMessage(steamID, '❌ Command not available.');
+                }
                 this.buyCartCommand(steamID, message);
             } else if (command === 'sellcart') {
+                if (isInvalidType) {
+                    return this.bot.sendMessage(steamID, '❌ Command not available.');
+                }
                 this.sellCartCommand(steamID, message);
             } else if (command === 'cart') {
+                if (isInvalidType) {
+                    return this.bot.sendMessage(steamID, '❌ Command not available.');
+                }
                 this.cartCommand(steamID);
             } else if (command === 'clearcart') {
+                if (isInvalidType) {
+                    return this.bot.sendMessage(steamID, '❌ Command not available.');
+                }
                 this.clearCartCommand(steamID);
             } else if (command === 'checkout') {
+                if (isInvalidType) {
+                    return this.bot.sendMessage(steamID, '❌ Command not available.');
+                }
                 this.checkoutCommand(steamID);
             } else if (command === 'cancel') {
+                if (isInvalidType) {
+                    return this.bot.sendMessage(steamID, '❌ Command not available.');
+                }
                 this.cancelCommand(steamID);
             } else if (command === 'queue') {
+                if (isInvalidType) {
+                    return this.bot.sendMessage(steamID, '❌ Command not available.');
+                }
                 this.queueCommand(steamID);
             } else if (['time', 'uptime', 'pure', 'rate', 'owner', 'discord', 'stock'].includes(command)) {
                 if (command === 'stock') {
                     return this.misc.miscCommand(steamID, command as Misc, message);
                 }
                 this.misc.miscCommand(steamID, command as Misc);
+            } else if (command === 'sku') {
+                this.getSKU(steamID, message);
+            } else if (command === 'message') {
+                if (isInvalidType) {
+                    return this.bot.sendMessage(steamID, '❌ Command not available.');
+                }
+                this.message.message(steamID, message);
             } else if (command === 'paints' && isAdmin) {
                 this.misc.paintsCommand(steamID);
             } else if (command === 'more') {
                 this.help.moreCommand(steamID);
             } else if (command === 'autokeys') {
                 this.manager.autokeysCommand(steamID);
-            } else if (command === 'message') {
-                this.message.message(steamID, message);
             } else if (['craftweapon', 'craftweapons', 'uncraftweapon', 'uncraftweapons'].includes(command)) {
                 void this.misc.weaponCommand(
                     steamID,
@@ -247,8 +279,6 @@ export default class Commands {
                 this.donateCartCommand(steamID);
             } else if (command === 'premium' && isAdmin) {
                 this.buyBPTFPremiumCommand(steamID, message);
-            } else if (command === 'sku' && isAdmin) {
-                this.getSKU(steamID, message);
             } else if (command === 'refreshschema' && isAdmin) {
                 this.manager.refreshSchema(steamID);
             } else if (command === 'crafttoken' && isAdmin) {

--- a/src/classes/Commands/sub-classes/Help.ts
+++ b/src/classes/Commands/sub-classes/Help.ts
@@ -11,6 +11,25 @@ export default class HelpCommands {
         const isAdmin = this.bot.isAdmin(steamID);
         const isCustomPricer = this.bot.pricelist.isUseCustomPricer;
 
+        if (steamID instanceof SteamID && steamID.redirectAnswerTo && steamID.type === 0) {
+            return this.bot.sendMessage(
+                steamID,
+                `\nDo not include characters <> nor [ ] - <> means required and [] means optional.` +
+                    "\n\n📜 Here's a list of my commands:" +
+                    '\n- ' +
+                    [
+                        '!help - Get a list of commands',
+                        '!how2trade - Guide on how to trade with the bot',
+                        '!price [amount] <name> - Get the price and stock of an item 💲📦',
+                        "!sku <Full Item Name|Item's sku> - Get the sku of an item.",
+                        "!owner - Get the owner's Steam profile and Backpack.tf links",
+                        '!message <your message> - Send a message to the owner of the bot 💬',
+                        "!discord - Get a link to join TF2Autobot and/or the owner's discord server 💬",
+                        '!more - Show more available commands list 📜'
+                    ].join('\n- ')
+            );
+        }
+
         this.bot.sendMessage(
             steamID,
             `📌 Note 📌${

--- a/src/classes/DiscordBot.ts
+++ b/src/classes/DiscordBot.ts
@@ -58,6 +58,10 @@ export default class DiscordBot {
             return; // Ignore webhook messages
         }
 
+        if (!message.content.startsWith('!')) {
+            return; // Ignore message that not start with !
+        }
+
         log.info(
             `Got new message ${String(message.content)} from ${message.author.tag} (${String(message.author.id)})`
         );

--- a/src/classes/DiscordBot.ts
+++ b/src/classes/DiscordBot.ts
@@ -61,12 +61,25 @@ export default class DiscordBot {
         log.info(
             `Got new message ${String(message.content)} from ${message.author.tag} (${String(message.author.id)})`
         );
-        if (!this.isDiscordAdmin(message.author.id)) {
-            return; // obey only admins
-        }
 
         if (!this.bot.isReady) {
             this.sendAnswer(message, '🛑 The bot is still booting up, please wait');
+            return;
+        }
+
+        if (!this.isDiscordAdmin(message.author.id)) {
+            try {
+                // Will return default invalid value
+                const dummySteamID = new SteamID(null);
+                dummySteamID.redirectAnswerTo = message;
+                await this.bot.handler.onMessage(dummySteamID, message.content);
+            } catch (err) {
+                log.error(err);
+                message.channel
+                    .send(`❌ Error:\n${JSON.stringify(err)}`)
+                    .catch(err => log.error('Failed to send error message to Discord:', err));
+            }
+
             return;
         }
 

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -459,25 +459,39 @@ export default class MyHandler extends Handler {
             return this.bot.sendMessage(steamID, '⚠️ The bot is updating, please wait until I am back online.');
         }
 
-        const steamID64 = steamID.toString();
-        if (!this.bot.friends.isFriend(steamID64)) {
-            return;
+        if (steamID.type !== 0) {
+            const steamID64 = steamID.toString();
+            if (!this.bot.friends.isFriend(steamID64)) {
+                return;
+            }
+
+            const friend = this.bot.friends.getFriend(steamID64);
+
+            if (friend === null) {
+                log.info(`Message from ${steamID64}: ${message}`);
+            } else {
+                log.info(`Message from ${friend.player_name} (${steamID64}): ${message}`);
+            }
+
+            if (this.recentlySentMessage[steamID64] !== undefined && this.recentlySentMessage[steamID64] >= 1) {
+                return;
+            }
+
+            this.recentlySentMessage[steamID64] =
+                (this.recentlySentMessage[steamID64] === undefined ? 0 : this.recentlySentMessage[steamID64]) + 1;
+        } else if (steamID instanceof SteamID && steamID.redirectAnswerTo) {
+            if (
+                this.recentlySentMessage[steamID.redirectAnswerTo.author.id] !== undefined &&
+                this.recentlySentMessage[steamID.redirectAnswerTo.author.id] >= 1
+            ) {
+                return;
+            }
+
+            this.recentlySentMessage[steamID.redirectAnswerTo.author.id] =
+                (this.recentlySentMessage[steamID.redirectAnswerTo.author.id] === undefined
+                    ? 0
+                    : this.recentlySentMessage[steamID.redirectAnswerTo.author.id]) + 1;
         }
-
-        const friend = this.bot.friends.getFriend(steamID64);
-
-        if (friend === null) {
-            log.info(`Message from ${steamID64}: ${message}`);
-        } else {
-            log.info(`Message from ${friend.player_name} (${steamID64}): ${message}`);
-        }
-
-        if (this.recentlySentMessage[steamID64] !== undefined && this.recentlySentMessage[steamID64] >= 1) {
-            return;
-        }
-
-        this.recentlySentMessage[steamID64] =
-            (this.recentlySentMessage[steamID64] === undefined ? 0 : this.recentlySentMessage[steamID64]) + 1;
 
         await this.commands.processMessage(steamID, message);
     }


### PR DESCRIPTION
Disabled commands:
- `!buy`
- `!sell`
- `buycart`
- `!sellcart`
- `!cart`
- `!clearcart`
- `!checkout`
- `!cancel`
- `!queue`
- `!message`

Admin-only commands made available for all:
- `!sku`

Some screenshots:
- Steam chat: ![image](https://user-images.githubusercontent.com/47635037/179504892-1f7d2ccb-078b-47a1-82f0-8c33c1261d5b.png)
- Discord: 
![image](https://user-images.githubusercontent.com/47635037/179505034-3cf2c641-9164-4eb4-93f5-01e7e8088215.png)
