### PR TITLE
🎨 Discord presence implementation

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -322,6 +322,9 @@ export default class Bot {
         log.debug('Setting status in Steam to "Snooze"');
         this.client.setPersona(EPersonaState.Snooze);
 
+        log.debug('Settings status in Discord to "idle"');
+        this.discordBot.halt();
+
         log.debug('Removing all listings due to halt mode turned on');
         await this.listings
             .removeAll()
@@ -338,6 +341,9 @@ export default class Bot {
 
         log.debug('Setting status in Steam to "Online"');
         this.client.setPersona(EPersonaState.Online);
+
+        log.debug('Settings status in Discord to "online"');
+        this.discordBot.unhalt();
     }
 
     private addListener(
@@ -991,6 +997,8 @@ export default class Bot {
 
             promise
                 .then(() => {
+                    this.discordBot.setPresence('online');
+
                     this.manager.pollInterval = 5 * 1000;
                     this.setReady = true;
                     this.handler.onReady();

--- a/src/classes/DiscordBot.ts
+++ b/src/classes/DiscordBot.ts
@@ -123,6 +123,28 @@ export default class DiscordBot {
         });
     }
 
+    setPresence(type: 'online' | 'halt'): void {
+        const opt = this.bot.options.discordChat[type];
+
+        this.client.user.setPresence({
+            activities: [
+                {
+                    name: opt.name,
+                    type: opt.type
+                }
+            ],
+            status: opt.status
+        });
+    }
+
+    halt(): void {
+        this.setPresence('halt');
+    }
+
+    unhalt(): void {
+        this.setPresence('online');
+    }
+
     isDiscordAdmin(discordID: Snowflake): boolean {
         return this.bot.getAdmins.some(admin => admin.discordID === discordID);
     }

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -465,6 +465,21 @@ export const DEFAULTS: JsonOptions = {
         additionalNotes: ''
     },
 
+    discordChat: {
+        online: {
+            // Default: "Listening to incoming offers"
+            type: 'LISTENING', // LISTENING | PLAYING | COMPETING | WATCHING
+            name: 'incoming offers',
+            status: 'online' // online | idle | dnd | invisible
+        },
+        halt: {
+            // Default: "Playing ? No, Halted ⛔"
+            type: 'PLAYING',
+            name: '? No, Halted ⛔',
+            status: 'idle'
+        }
+    },
+
     discordWebhook: {
         ownerID: [],
         displayName: '',
@@ -1517,6 +1532,19 @@ interface ManualReview extends OnlyEnable {
     additionalNotes?: string;
 }
 
+// ------------ Discord Chat ---------------
+
+interface DiscordChat {
+    online?: DiscordChatStatus;
+    halt?: DiscordChatStatus;
+}
+
+interface DiscordChatStatus {
+    name: string;
+    type?: 'PLAYING' | 'LISTENING' | 'COMPETING' | 'WATCHING' | 'STREAMING';
+    status?: 'online' | 'idle' | 'dnd' | 'invisible';
+}
+
 // ------------ Discord Webhook ------------
 
 interface DiscordWebhook {
@@ -2011,6 +2039,7 @@ export interface JsonOptions {
     crafting?: Crafting;
     offerReceived?: OfferReceived;
     manualReview?: ManualReview;
+    discordChat?: DiscordChat;
     discordWebhook?: DiscordWebhook;
     customMessage?: CustomMessage;
     commands?: Commands;

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -91,7 +91,7 @@ export const optionsSchema: jsonschema.Schema = {
                     type: 'string'
                 }
             },
-            required: ['type', 'name', 'url', 'status'],
+            required: ['type', 'name', 'status'],
             additionalProperties: false
         },
         'discord-webhook-misc': {

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -78,6 +78,22 @@ export const optionsSchema: jsonschema.Schema = {
             required: ['note'],
             additionalProperties: false
         },
+        'discord-chat': {
+            type: 'object',
+            properties: {
+                type: {
+                    type: 'string'
+                },
+                name: {
+                    type: 'string'
+                },
+                status: {
+                    type: 'string'
+                }
+            },
+            required: ['type', 'name', 'url', 'status'],
+            additionalProperties: false
+        },
         'discord-webhook-misc': {
             type: 'object',
             properties: {
@@ -1411,6 +1427,17 @@ export const optionsSchema: jsonschema.Schema = {
                 'additionalNotes'
             ],
             additionalProperties: false
+        },
+        discordChat: {
+            type: 'object',
+            properties: {
+                online: {
+                    $ref: '#/definitions/discord-chat'
+                },
+                halt: {
+                    $ref: '#/definitions/discord-chat'
+                }
+            }
         },
         discordWebhook: {
             type: 'object',


### PR DESCRIPTION
### New options:
```json
// DO NOT INCLUDE COMMENTS (RED HIGHLIGHTS) IN YOUR OPTIONS.JSON FILE

"discordChat": {
        "online": {
            // Default: "Listening to incoming offers"
            "type": "LISTENING", // LISTENING | PLAYING | COMPETING | WATCHING
            "name": "incoming offers",
            "status": "online" // online | idle | dnd | invisible
        },
        "halt": {
            // Default: "Playing ? No, Halted ⛔"
            "type": "PLAYING",
            "name": "? No, Halted ⛔",
            "status": "idle"
        }
    }
```

### Note:
- It's impossible to create custom status. Idk why, probably just Discord.js.


### Screenshots:
- When online and ready:
![image](https://user-images.githubusercontent.com/47635037/179933866-cae0ab4b-f9af-40f8-8fa4-56806188abae.png)

- When put into halted mode (`!halt`):
![image](https://user-images.githubusercontent.com/47635037/179933933-cb2af9be-0428-46b1-b258-894afb3b3a1f.png)