### PR TITLE
🚮 remove unnecessary operation

### DIFF
--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -650,10 +650,7 @@ export default class Pricelist extends EventEmitter {
 
         await this.validateEntry(entry, src, isBulk);
 
-        // Remove old price
-        await this.removePrice(priceKey, false);
-
-        // Add new price
+        // Update to new price
         this.prices[priceKey] = entry;
 
         if (emitChange) {


### PR DESCRIPTION
Should fix this annoying problem:
![image](https://user-images.githubusercontent.com/47635037/179943475-dd3d2f9f-63eb-4e7e-b88d-351515e8069e.png)
