### PR TITLE
🔨 Disable check for missing/mismatching listings during halt mode

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -325,6 +325,9 @@ export default class Bot {
         log.debug('Settings status in Discord to "idle"');
         this.discordBot.halt();
 
+        // disable auto-check for missing/mismatching listings
+        clearInterval(this.autoRefreshListingsInterval);
+
         log.debug('Removing all listings due to halt mode turned on');
         await this.listings
             .removeAll()
@@ -344,6 +347,9 @@ export default class Bot {
 
         log.debug('Settings status in Discord to "online"');
         this.discordBot.unhalt();
+
+        // Re-initialize auto-check for missing/mismatching listings
+        this.startAutoRefreshListings();
     }
 
     private addListener(


### PR DESCRIPTION
Make sure to not run the automatic check for missing/mismatching listings during halt mode, or else, this will run over and over:

![image](https://user-images.githubusercontent.com/47635037/179947770-17f8b3d9-7bbd-4fd4-a2a7-16d10637d762.png)
