### PR TITLE
Check bans as class

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -223,7 +223,7 @@ export default class Bot {
     private async checkAdminBanned(): Promise<boolean> {
         let banned = false;
         const check = async (steamid: string) => {
-            const v = new Bans(this, this.userID, steamid);
+            const v = new Bans(this, this.userID, steamid, false);
             const result = await v.isBanned();
             banned = banned ? true : result.isBanned;
         };

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -216,19 +216,16 @@ export default class Bot {
     }
 
     async checkBanned(steamID: SteamID | string): Promise<IsBanned> {
-        let v = new Bans(this, this.userID, steamID.toString());
-        return await v.isBanned().finally(() => {
-            v = undefined;
-        });
+        const v = new Bans(this, this.userID, steamID.toString());
+        return await v.isBanned();
     }
 
     private async checkAdminBanned(): Promise<boolean> {
         let banned = false;
         const check = async (steamid: string) => {
-            let v = new Bans(this, this.userID, steamid, false);
+            const v = new Bans(this, this.userID, steamid, false);
             const result = await v.isBanned();
             banned = banned ? true : result.isBanned;
-            v = undefined;
         };
 
         const steamids = this.admins.map(steamID => steamID.getSteamID64());

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -215,17 +215,20 @@ export default class Bot {
         return this.itemStatsWhitelist;
     }
 
-    checkBanned(steamID: SteamID | string): Promise<IsBanned> {
-        const v = new Bans(this, this.userID, steamID.toString());
-        return Promise.resolve(v.isBanned());
+    async checkBanned(steamID: SteamID | string): Promise<IsBanned> {
+        let v = new Bans(this, this.userID, steamID.toString());
+        return await v.isBanned().finally(() => {
+            v = undefined;
+        });
     }
 
     private async checkAdminBanned(): Promise<boolean> {
         let banned = false;
         const check = async (steamid: string) => {
-            const v = new Bans(this, this.userID, steamid, false);
+            let v = new Bans(this, this.userID, steamid, false);
             const result = await v.isBanned();
             banned = banned ? true : result.isBanned;
+            v = undefined;
         };
 
         const steamids = this.admins.map(steamID => steamID.getSteamID64());

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -32,7 +32,7 @@ import MyHandler from './MyHandler/MyHandler';
 import Groups from './Groups';
 
 import log from '../lib/logger';
-import { IsBanned, isBanned } from '../lib/bans';
+import Bans, { IsBanned } from '../lib/bans';
 import { sendStats } from '../lib/DiscordWebhook/export';
 
 import Options from './Options';
@@ -216,22 +216,15 @@ export default class Bot {
     }
 
     checkBanned(steamID: SteamID | string): Promise<IsBanned> {
-        return Promise.resolve(
-            isBanned(
-                steamID,
-                this.options.bptfApiKey,
-                this.options.mptfApiKey,
-                this.userID,
-                this.options.miscSettings.reputationCheck.checkMptfBanned,
-                this.options.miscSettings.reputationCheck.reptfAsPrimarySource
-            )
-        );
+        const v = new Bans(this, this.userID, steamID.toString());
+        return Promise.resolve(v.isBanned());
     }
 
     private async checkAdminBanned(): Promise<boolean> {
         let banned = false;
         const check = async (steamid: string) => {
-            const result = await isBanned(steamid, this.options.bptfApiKey, '', null, false, false, false);
+            const v = new Bans(this, this.userID, steamid);
+            const result = await v.isBanned();
             banned = banned ? true : result.isBanned;
         };
 

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -1166,7 +1166,7 @@ interface MiscSettings {
     pricecheckAfterTrade?: OnlyEnable;
 }
 
-interface ReputationCheck {
+export interface ReputationCheck {
     checkMptfBanned?: boolean;
     reptfAsPrimarySource?: boolean;
 }

--- a/src/lib/bans.ts
+++ b/src/lib/bans.ts
@@ -16,8 +16,6 @@ interface SiteResult {
 }
 
 export default class Bans {
-    private readonly repOpt: ReputationCheck;
-
     private _isBptfBanned: boolean = null;
 
     private _isBptfSteamRepBanned: boolean = null;
@@ -34,7 +32,11 @@ export default class Bans {
         private readonly steamID: string,
         private readonly showLog = true
     ) {
-        this.repOpt = this.bot.options.miscSettings.reputationCheck;
+        //
+    }
+
+    private get repOpt(): ReputationCheck {
+        return this.bot.options.miscSettings.reputationCheck;
     }
 
     async isBanned(): Promise<IsBanned> {

--- a/src/lib/bans.ts
+++ b/src/lib/bans.ts
@@ -138,7 +138,8 @@ export default class Bans {
                 method: 'POST',
                 url: 'https://rep.tf/api/bans?str=' + this.steamID,
                 headers: {
-                    'User-Agent': 'TF2Autobot@' + process.env.BOT_VERSION
+                    'User-Agent':
+                        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36'
                 }
             })
                 .then(response => {


### PR DESCRIPTION
The problem with previous function based bans check is that, this
https://github.com/TF2Autobot/tf2autobot/blob/a3465225bd7973c502cc1b092e098246765f3bd8/src/lib/bans.ts#L7
and
https://github.com/TF2Autobot/tf2autobot/blob/a3465225bd7973c502cc1b092e098246765f3bd8/src/lib/bans.ts#L19

Might be conflicting when we're processing a lot of offer at the same time.
Doing it in class will make everything isolated, but I am not sure if this will cause a memory leak, or will be managed my GC itself.
