### PR TITLE
🐛 Fix bot exit TF2 and never play again

### DIFF
--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -1653,11 +1653,6 @@ export default class Trades {
             offer.itemsToGive.forEach(item => this.bot.inventoryManager.getInventory.removeItem(item.assetid));
         }
 
-        // Exit all running apps ("TF2Autobot" or custom, and Team Fortress 2)
-        // Will play again after craft/smelt/sort inventory job
-        // https://github.com/TF2Autobot/tf2autobot/issues/527
-        this.bot.client.gamesPlayed([]);
-
         if (
             offer.state === TradeOfferManager.ETradeOfferState['Active'] ||
             offer.state === TradeOfferManager.ETradeOfferState['CreatedNeedsConfirmation'] ||
@@ -1668,6 +1663,11 @@ export default class Trades {
             // Offer is active, or countered, or declined countered, no need to fetch
             // Do nothing
         } else {
+            // Exit all running apps ("TF2Autobot" or custom, and Team Fortress 2)
+            // Will play again after craft/smelt/sort inventory job
+            // https://github.com/TF2Autobot/tf2autobot/issues/527
+            this.bot.client.gamesPlayed([]);
+
             this.offerChangedAcc.push({ offer, oldState, timeTakenToComplete });
             log.debug('Accumulated offerChanged: ', this.offerChangedAcc.length);
 


### PR DESCRIPTION
This bug was introduced in the [v5.1.0](https://github.com/TF2Autobot/tf2autobot/releases/tag/v5.1.0) ([#1228](https://github.com/TF2Autobot/tf2autobot/pull/1228)) update.
The bot will go "Online" and never play Team Fortress 2 again if the bot sends an offer, counter an offer, or countered offer is declined.

This should fix this issue.
![image](https://user-images.githubusercontent.com/47635037/181293492-fbbb19ad-c1dd-40ef-bb2a-d2af02bbd7db.png)
