### PR TITLE
🔨 Add Jungle Inferno weapons to the craft list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@tf2autobot/steamcommunity": "^3.45.4",
                 "@tf2autobot/tf2": "^1.2.1",
                 "@tf2autobot/tf2-currencies": "^2.0.1",
-                "@tf2autobot/tf2-schema": "^4.0.0",
+                "@tf2autobot/tf2-schema": "^4.1.1",
                 "@tf2autobot/tf2-sku": "^2.0.3",
                 "@tf2autobot/tradeoffer-manager": "^2.14.1",
                 "axios": "^0.27.2",
@@ -2097,9 +2097,9 @@
             }
         },
         "node_modules/@tf2autobot/tf2-schema": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-4.0.0.tgz",
-            "integrity": "sha512-pf8cp6ZWRfpDdt52aGLong8N+g8n4Is9MIHrDwIGwoIkCnGyJ0WgZqXrhru93jtntWlTTfQ+5YwHuOw8hjx66w==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-4.1.1.tgz",
+            "integrity": "sha512-rntc7zkV2mM+6vrkwV+tUkP3emW6N0A6iM80+F33dvlVuHi+gWbqrc3wW8xC/NrW/kJjEiT9u8KyM7zEQAYu6w==",
             "dependencies": {
                 "@tf2autobot/tf2-sku": "^2.0.3",
                 "async": "^3.2.4",
@@ -12543,9 +12543,9 @@
             }
         },
         "@tf2autobot/tf2-schema": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-4.0.0.tgz",
-            "integrity": "sha512-pf8cp6ZWRfpDdt52aGLong8N+g8n4Is9MIHrDwIGwoIkCnGyJ0WgZqXrhru93jtntWlTTfQ+5YwHuOw8hjx66w==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-4.1.1.tgz",
+            "integrity": "sha512-rntc7zkV2mM+6vrkwV+tUkP3emW6N0A6iM80+F33dvlVuHi+gWbqrc3wW8xC/NrW/kJjEiT9u8KyM7zEQAYu6w==",
             "requires": {
                 "@tf2autobot/tf2-sku": "^2.0.3",
                 "async": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@tf2autobot/steamcommunity": "^3.45.4",
         "@tf2autobot/tf2": "^1.2.1",
         "@tf2autobot/tf2-currencies": "^2.0.1",
-        "@tf2autobot/tf2-schema": "^4.0.0",
+        "@tf2autobot/tf2-schema": "^4.1.1",
         "@tf2autobot/tf2-sku": "^2.0.3",
         "@tf2autobot/tradeoffer-manager": "^2.14.1",
         "axios": "^0.27.2",


### PR DESCRIPTION
Previously, these weapons are not included in the craftable weapons (for crafting into scrap metals or tokens, not to trade):
- Dragon's Fury (1178)
- Thermal Thruster (1179)
- Gas Passer (1180)
- Hot Hand (1181)
- Second Banana (1190)

This should now be included.