### PR TITLE
🐛 Show spot price instead of current price on the trade summary

### DIFF
--- a/src/lib/tools/summarizeItems.ts
+++ b/src/lib/tools/summarizeItems.ts
@@ -121,14 +121,13 @@ function listPrices(offer: TradeOffer, bot: Bot, isSteamChat: boolean): string {
             continue;
         }
 
+        buyPrice = new Currencies(prices[priceKey].buy).toString();
+        sellPrice = new Currencies(prices[priceKey].sell).toString();
+
         const entry = bot.pricelist.getPriceBySkuOrAsset({ priceKey, onlyEnabled: false });
+
         if (entry !== null) {
-            buyPrice = entry.buy.toString();
-            sellPrice = entry.sell.toString();
             autoprice = entry.autoprice ? `autopriced${entry.isPartialPriced ? ' - ppu' : ''}` : 'manual';
-        } else {
-            buyPrice = new Currencies(prices[priceKey].buy).toString();
-            sellPrice = new Currencies(prices[priceKey].sell).toString();
         }
 
         const name = testPriceKey(priceKey)


### PR DESCRIPTION
Fixes:
![image](https://user-images.githubusercontent.com/47635037/183248431-8fb6b797-b984-43db-a3dd-fa7d9c1cc988.png)