### PR TITLE
🐛 Fix bot removing non-friends (should not) on !clearfriends command

### DIFF
--- a/src/classes/Commands/sub-classes/Manager.ts
+++ b/src/classes/Commands/sub-classes/Manager.ts
@@ -434,7 +434,11 @@ export default class ManagerCommands {
                 return this.bot.sendMessage(steamID, `❌ Error getting friendlist: ${JSON.stringify(err)}`);
             }
 
-            const friendsToRemove = Object.keys(friendlist).filter(steamid => !friendsToKeep.includes(steamid));
+            const friendsToRemove = Object.keys(friendlist).filter(
+                // Make sure only friends, not overall
+                friendID => !friendsToKeep.includes(friendID) && friendlist[friendID] === EFriendRelationship.Friend
+            );
+
             if (friendsToRemove.length === 0) {
                 return this.bot.sendMessage(steamID, `❌ I don't have any friends to remove.`);
             }


### PR DESCRIPTION
Fixes:
Even when your bot only has 1 friend (you, or anyone in the `KEEP` array), the bot still says removing some thousands of friends.