### PR TITLE
✨ Add an option to retain old group on highValue hold

### DIFF
--- a/src/classes/MyHandler/offer/accepted/updateListings.ts
+++ b/src/classes/MyHandler/offer/accepted/updateListings.ts
@@ -455,7 +455,9 @@ export default function updateListings(
                     let msg =
                         `I have temporarily disabled ${name} (${priceKey}) because it contains some high value spells/parts.` +
                         `\nYou can manually price it with "!update sku=${priceKey}&enabled=true&<buy and sell price>"` +
-                        ` or just re-enable it with "!update sku=${priceKey}&enabled=true${opt.highValue.retainOldGroup ? '' : `&group=${oldGroup}".`}` +
+                        ` or just re-enable it with "!update sku=${priceKey}&enabled=true${
+                            opt.highValue.retainOldGroup ? '' : `&group=${oldGroup}".`
+                        }` +
                         '\n\nItem information:\n\n- ';
 
                     const theirCount = highValue.theirItems.length;

--- a/src/classes/MyHandler/offer/accepted/updateListings.ts
+++ b/src/classes/MyHandler/offer/accepted/updateListings.ts
@@ -439,38 +439,23 @@ export default function updateListings(
             // If item received is high value, temporarily disable that item so it will not be sellable.
             const oldGroup = priceListEntry.group;
 
-            const entry: EntryData = {
-                sku: priceKey, // required
-                enabled: false, // required
-                autoprice: priceListEntry.autoprice, // required
-                min: priceListEntry.min, // required
-                max: priceListEntry.max, // required
-                intent: priceListEntry.intent, // required
-                group: 'highValue'
-            };
-
-            if (!priceListEntry.autoprice) {
-                // if not autopriced, then explicitly set the buy/sell prices
-                // with the current buy/sell prices
-                entry.buy = {
-                    keys: priceListEntry.buy.keys,
-                    metal: priceListEntry.buy.metal
-                };
-                entry.sell = {
-                    keys: priceListEntry.sell.keys,
-                    metal: priceListEntry.sell.metal
-                };
+            priceListEntry.enabled = false;
+            if (!opt.highValue.retainOldGroup) {
+                priceListEntry.group = opt.highValue.customGroup ? opt.highValue.customGroup : 'highValue';
             }
 
+            delete priceListEntry.name;
+            delete priceListEntry.time;
+
             bot.pricelist
-                .updatePrice({ priceKey: entry.sku, entryData: entry, emitChange: true })
+                .updatePrice({ priceKey, entryData: priceListEntry, emitChange: true })
                 .then(() => {
                     log.debug(`✅ Automatically disabled ${priceKey}, which is a high value item.`);
 
                     let msg =
                         `I have temporarily disabled ${name} (${priceKey}) because it contains some high value spells/parts.` +
                         `\nYou can manually price it with "!update sku=${priceKey}&enabled=true&<buy and sell price>"` +
-                        ` or just re-enable it with "!update sku=${priceKey}&enabled=true&group=${oldGroup}".` +
+                        ` or just re-enable it with "!update sku=${priceKey}&enabled=true${opt.highValue.retainOldGroup ? '' : `&group=${oldGroup}".`}` +
                         '\n\nItem information:\n\n- ';
 
                     const theirCount = highValue.theirItems.length;

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -218,6 +218,8 @@ export const DEFAULTS: JsonOptions = {
 
     highValue: {
         enableHold: true,
+        retainOldGroup: false,
+        customGroup: 'highValue',
         spells: {
             names: [],
             exceptionSkus: []
@@ -1319,6 +1321,8 @@ interface NotifyTradePartner {
 
 export interface HighValue {
     enableHold?: boolean;
+    retainOldGroup?: boolean;
+    customGroup?: string;
     spells?: HighValueContent;
     sheens?: HighValueContent;
     killstreakers?: HighValueContent;

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -930,7 +930,16 @@ export const optionsSchema: jsonschema.Schema = {
                     $ref: '#/definitions/high-value-content'
                 }
             },
-            required: ['enableHold', 'retainOldGroup', 'customGroup', 'spells', 'sheens', 'killstreakers', 'strangeParts', 'painted'],
+            required: [
+                'enableHold',
+                'retainOldGroup',
+                'customGroup',
+                'spells',
+                'sheens',
+                'killstreakers',
+                'strangeParts',
+                'painted'
+            ],
             additionalProperties: false
         },
         normalize: {

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -875,6 +875,12 @@ export const optionsSchema: jsonschema.Schema = {
                 enableHold: {
                     type: 'boolean'
                 },
+                retainOldGroup: {
+                    type: 'boolean'
+                },
+                customGroup: {
+                    type: 'string'
+                },
                 spells: {
                     type: 'object',
                     properties: {
@@ -924,7 +930,7 @@ export const optionsSchema: jsonschema.Schema = {
                     $ref: '#/definitions/high-value-content'
                 }
             },
-            required: ['enableHold', 'spells', 'sheens', 'killstreakers', 'strangeParts', 'painted'],
+            required: ['enableHold', 'retainOldGroup', 'customGroup', 'spells', 'sheens', 'killstreakers', 'strangeParts', 'painted'],
             additionalProperties: false
         },
         normalize: {


### PR DESCRIPTION
New options:
- `highValue.retainOldGroup` (default is `false`)
- `highValue.customGroup` (default is `highValue`)

If the `highValue.retainOldGroup` is set to `true`, when an item is put to hold because it contains some of the high-value attachments, the group will remain untouched.

![image](https://user-images.githubusercontent.com/47635037/183312157-337ca8d9-9630-4e4d-ab5f-6ab604644548.png)
