### PR TITLE
🐛 Fix profit/loss from over/underpay info on summary (again)

### DIFF
--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -140,8 +140,6 @@ export default class MyHandler extends Handler {
 
     private hasInvalidValueException = false;
 
-    private isTradingKeys = false;
-
     get customGameName(): string {
         const customGameName = this.opt.miscSettings.game.customName;
         return customGameName ? customGameName : `TF2Autobot`;
@@ -1458,7 +1456,6 @@ export default class MyHandler extends Handler {
                 // Check overstock / understock on keys
                 const diff = itemsDiff['5021;6'] as number | null;
                 // If the diff is greater than 0 then we are buying, less than is selling
-                this.isTradingKeys = true;
                 const isBuying = diff > 0;
                 const inventoryManager = this.bot.inventoryManager;
                 const amountCanTrade = inventoryManager.amountCanTrade({
@@ -2089,9 +2086,8 @@ export default class MyHandler extends Handler {
                 } else if (offer.state === TradeOfferManager.ETradeOfferState['InEscrow']) {
                     if (notifyOpt.onSuccessAcceptedEscrow) acceptEscrow(offer, this.bot);
                 } else if (offer.state === TradeOfferManager.ETradeOfferState['Declined']) {
-                    if (notifyOpt.onDeclined) declined(offer, this.bot, this.isTradingKeys);
+                    if (notifyOpt.onDeclined) declined(offer, this.bot);
                     offer.data('isDeclined', true);
-                    this.isTradingKeys = false; // reset
                 } else if (offer.state === TradeOfferManager.ETradeOfferState['Canceled']) {
                     if (notifyOpt.onCancelled) cancelled(offer, oldState, this.bot);
 
@@ -2178,8 +2174,7 @@ export default class MyHandler extends Handler {
 
                 this.autokeys.check();
 
-                const result = processAccepted(offer, this.bot, this.isTradingKeys, timeTakenToComplete);
-                this.isTradingKeys = false; // reset
+                const result = processAccepted(offer, this.bot, timeTakenToComplete);
 
                 highValue.isDisableSKU = result.isDisableSKU;
                 highValue.theirItems = result.theirHighValuedItems;
@@ -2193,7 +2188,7 @@ export default class MyHandler extends Handler {
                 clearTimeout(this.resetSentSummaryTimeout);
                 this.sentSummary[offer.id] = true;
 
-                processDeclined(offer, this.bot, this.isTradingKeys);
+                processDeclined(offer, this.bot);
                 MyHandler.removePolldataKeys(offer);
             }
         }
@@ -2254,7 +2249,7 @@ export default class MyHandler extends Handler {
         }
 
         if (action === 'skip') {
-            void sendReview(offer, this.bot, meta, this.isTradingKeys);
+            void sendReview(offer, this.bot, meta);
             return;
         }
     }

--- a/src/classes/MyHandler/offer/accepted/processAccepted.ts
+++ b/src/classes/MyHandler/offer/accepted/processAccepted.ts
@@ -10,7 +10,6 @@ import { sendTradeSummary } from '../../../../lib/DiscordWebhook/export';
 export default function processAccepted(
     offer: i.TradeOffer,
     bot: Bot,
-    isTradingKeys: boolean,
     timeTakenToComplete: number
 ): { theirHighValuedItems: string[]; isDisableSKU: string[]; items: i.Items | undefined } {
     const opt = bot.options;
@@ -184,7 +183,6 @@ export default function processAccepted(
             timeTakenToComplete,
             timeTakenToProcessOrConstruct,
             timeTakenToCounterOffer,
-            isTradingKeys,
             isOfferSent
         );
     } else {
@@ -200,7 +198,7 @@ export default function processAccepted(
 
         const keyPrices = bot.pricelist.getKeyPrices;
 
-        const value = t.valueDiff(offer, keyPrices, isTradingKeys);
+        const value = t.valueDiff(offer);
         const itemList = t.listItems(offer, bot, itemsName, true);
 
         void sendToAdmin(

--- a/src/classes/MyHandler/offer/notify/declined.ts
+++ b/src/classes/MyHandler/offer/notify/declined.ts
@@ -2,13 +2,13 @@ import { Action, Meta, TradeOffer } from '@tf2autobot/tradeoffer-manager';
 import { valueDiff, summarizeToChat } from '../../../../lib/tools/export';
 import Bot from '../../../Bot';
 
-export default function declined(offer: TradeOffer, bot: Bot, isTradingKeys: boolean): void {
+export default function declined(offer: TradeOffer, bot: Bot): void {
     const opt = bot.options;
 
     const offerReason = offer.data('action') as Action;
     const meta = offer.data('meta') as Meta;
     const keyPrices = bot.pricelist.getKeyPrices;
-    const value = valueDiff(offer, keyPrices, isTradingKeys);
+    const value = valueDiff(offer);
     const manualReviewDisabled = !opt.manualReview.enable;
 
     const declined = '/pre ❌ Ohh nooooes! The offer is no longer available. Reason: The offer has been declined';

--- a/src/classes/MyHandler/offer/processDeclined.ts
+++ b/src/classes/MyHandler/offer/processDeclined.ts
@@ -5,7 +5,7 @@ import * as t from '../../../lib/tools/export';
 import sendTradeDeclined from '../../../lib/DiscordWebhook/sendTradeDeclined';
 import { KeyPrices } from '../../../classes/Pricelist';
 
-export default function processDeclined(offer: i.TradeOffer, bot: Bot, isTradingKeys: boolean): void {
+export default function processDeclined(offer: i.TradeOffer, bot: Bot): void {
     const opt = bot.options;
 
     const declined: Declined = {
@@ -268,7 +268,7 @@ export default function processDeclined(offer: i.TradeOffer, bot: Bot, isTrading
         offer.data('processOfferTime')) as number;
 
     if (isWebhookEnabled) {
-        void sendTradeDeclined(offer, declined, bot, timeTakenToProcessOrConstruct, isTradingKeys, isOfferSent);
+        void sendTradeDeclined(offer, declined, bot, timeTakenToProcessOrConstruct, isOfferSent);
     } else {
         const itemsName = {
             invalid: declined.invalidItems, // 🟨_INVALID_ITEMS
@@ -280,7 +280,7 @@ export default function processDeclined(offer: i.TradeOffer, bot: Bot, isTrading
             highValue: declined.highValue.concat(declined.highNotSellingItems)
         };
         const keyPrices = bot.pricelist.getKeyPrices;
-        const value = t.valueDiff(offer, keyPrices, isTradingKeys);
+        const value = t.valueDiff(offer);
         const itemList = t.listItems(offer, bot, itemsName, true);
 
         sendToAdmin(bot, offer, value, itemList, keyPrices, isOfferSent, timeTakenToProcessOrConstruct);

--- a/src/classes/MyHandler/offer/review/process-review.ts
+++ b/src/classes/MyHandler/offer/review/process-review.ts
@@ -3,9 +3,8 @@ import * as re from './reasons/export-reasons';
 import Bot from '../../../Bot';
 import { ValueDiff, valueDiff } from '../../../../lib/tools/export';
 
-export default function processReview(offer: TradeOffer, meta: Meta, bot: Bot, isTradingKeys: boolean): Content {
-    const keyPrices = bot.pricelist.getKeyPrices;
-    const value = valueDiff(offer, keyPrices, isTradingKeys);
+export default function processReview(offer: TradeOffer, meta: Meta, bot: Bot): Content {
+    const value = valueDiff(offer);
     const reasons = meta.uniqueReasons;
     const reviewReasons: string[] = [];
 

--- a/src/classes/MyHandler/offer/review/send-review.ts
+++ b/src/classes/MyHandler/offer/review/send-review.ts
@@ -8,17 +8,12 @@ import * as t from '../../../../lib/tools/export';
 import { KeyPrices } from 'src/classes/Pricelist';
 import { Links } from '../../../../lib/tools/export';
 
-export default async function sendReview(
-    offer: TradeOffer,
-    bot: Bot,
-    meta: Meta,
-    isTradingKeys: boolean
-): Promise<void> {
+export default async function sendReview(offer: TradeOffer, bot: Bot, meta: Meta): Promise<void> {
     const opt = bot.options;
     const time = t.timeNow(bot.options);
     const keyPrices = bot.pricelist.getKeyPrices;
     const links = t.generateLinks(offer.partner.toString());
-    const content = processReview(offer, meta, bot, isTradingKeys);
+    const content = processReview(offer, meta, bot);
 
     const hasCustomNote = !(opt.manualReview.invalidItems.note !== '' ||
         opt.manualReview.disabledItems.note !== '' ||

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -425,7 +425,7 @@ export default class Trades {
 
             if (opt.sendAlert.enable && opt.sendAlert.failedAccept) {
                 const keyPrices = this.bot.pricelist.getKeyPrices;
-                const value = t.valueDiff(offer, keyPrices, false);
+                const value = t.valueDiff(offer);
 
                 if (opt.discordWebhook.sendAlert.enable && opt.discordWebhook.sendAlert.url.main !== '') {
                     const summary = t.summarizeToChat(
@@ -630,7 +630,7 @@ export default class Trades {
 
                                 if (opt.sendAlert.enable && opt.sendAlert.failedAccept) {
                                     const keyPrices = this.bot.pricelist.getKeyPrices;
-                                    const value = t.valueDiff(offer, keyPrices, false);
+                                    const value = t.valueDiff(offer);
 
                                     if (
                                         opt.discordWebhook.sendAlert.enable &&

--- a/src/lib/DiscordWebhook/sendTradeDeclined.ts
+++ b/src/lib/DiscordWebhook/sendTradeDeclined.ts
@@ -11,7 +11,6 @@ export default async function sendTradeDeclined(
     declined: Declined,
     bot: Bot,
     timeTakenToProcessOrConstruct: number,
-    isTradingKeys: boolean,
     isOfferSent: boolean
 ): Promise<void> {
     const optBot = bot.options;
@@ -43,7 +42,7 @@ export default async function sendTradeDeclined(
           };
 
     const keyPrices = bot.pricelist.getKeyPrices;
-    const value = t.valueDiff(offer, keyPrices, isTradingKeys);
+    const value = t.valueDiff(offer);
     const summary = t.summarizeToChat(offer, bot, 'declined', true, value, keyPrices, false, isOfferSent);
 
     const details = await getPartnerDetails(offer, bot);

--- a/src/lib/DiscordWebhook/sendTradeSummary.ts
+++ b/src/lib/DiscordWebhook/sendTradeSummary.ts
@@ -15,7 +15,6 @@ export default async function sendTradeSummary(
     timeTakenToComplete: number,
     timeTakenToProcessOrConstruct: number,
     timeTakenToCounterOffer: number | undefined,
-    isTradingKeys: boolean,
     isOfferSent: boolean | undefined
 ): Promise<void> {
     const optBot = bot.options;
@@ -44,7 +43,7 @@ export default async function sendTradeSummary(
           };
 
     const keyPrices = bot.pricelist.getKeyPrices;
-    const value = t.valueDiff(offer, keyPrices, isTradingKeys);
+    const value = t.valueDiff(offer);
     const summary = t.summarizeToChat(offer, bot, 'summary-accepted', true, value, keyPrices, false, isOfferSent);
 
     // Mention owner on the sku(s) specified in discordWebhook.tradeSummary.mentionOwner.itemSkus

--- a/src/lib/tools/valueDiff.ts
+++ b/src/lib/tools/valueDiff.ts
@@ -1,36 +1,23 @@
-import { TradeOffer } from '@tf2autobot/tradeoffer-manager';
+import { ItemsValue, TradeOffer } from '@tf2autobot/tradeoffer-manager';
 import Currencies from '@tf2autobot/tf2-currencies';
-import { KeyPrices } from '../../classes/Pricelist';
 
-export default function valueDiff(offer: TradeOffer, keyPrices: KeyPrices, isTradingKeys: boolean): ValueDiff {
-    let value = offer.data('value') as ItemValue;
+export default function valueDiff(offer: TradeOffer): ValueDiff {
+    const value = offer.data('value') as ItemsValue;
 
     if (!value) {
         return { ourValue: 0, theirValue: 0, diff: 0, diffRef: 0, diffKey: '' };
     }
 
-    value = {
-        our: new Currencies({ keys: value.our.keys, metal: value.our.metal }),
-        their: new Currencies({ keys: value.their.keys, metal: value.their.metal })
-    };
-
-    const ourValue = value.our.toValue(keyPrices.sell.metal);
-    const theirValue = value.their.toValue(isTradingKeys ? keyPrices.buy.metal : keyPrices.sell.metal);
-    const diff = theirValue - ourValue;
+    const diff = value.their.total - value.our.total;
     const absoluteValue = Math.abs(diff);
 
     return {
-        ourValue,
-        theirValue,
+        ourValue: value.our.total,
+        theirValue: value.their.total,
         diff,
         diffRef: Currencies.toRefined(absoluteValue),
-        diffKey: Currencies.toCurrencies(absoluteValue, keyPrices.sell.metal).toString()
+        diffKey: Currencies.toCurrencies(absoluteValue, value.rate).toString()
     };
-}
-
-interface ItemValue {
-    our: Currencies;
-    their: Currencies;
 }
 
 export interface ValueDiff {


### PR DESCRIPTION
#1173 extension
- The core issue is in the [src/lib/tools/valueDiff.ts](https://github.com/TF2Autobot/tf2autobot/compare/development...1173-extension?expand=1#diff-dadd3c4d540560a008f3bf2b990b0bfec4e9d4c0bd70560c7b2f5851967747a7):
    - Instead of getting the `keys` and `metal`, we just take the `total` value.
    - Also use the spot key rate instead of the current key rate.

![image](https://user-images.githubusercontent.com/47635037/184396226-6e6dd7a7-b7e7-43fa-8d59-09161f4af1e7.png)
