### PR TITLE
↩ Revert listings note character limit to 200

### DIFF
--- a/src/schemas/pricelist-json/listing-note.ts
+++ b/src/schemas/pricelist-json/listing-note.ts
@@ -8,7 +8,7 @@ export const listingSchema: jsonschema.Schema = {
             anyOf: [
                 {
                     type: 'string',
-                    maxLength: 180
+                    maxLength: 200
                 },
                 {
                     type: 'null'
@@ -19,7 +19,7 @@ export const listingSchema: jsonschema.Schema = {
             anyOf: [
                 {
                     type: 'string',
-                    maxLength: 180
+                    maxLength: 200
                 },
                 {
                     type: 'null'


### PR DESCRIPTION
Might be useful if you want to make a custom listing note (without any parameters).
If still have parameters, it will automatically be trimmed to 200 characters.