### PR TITLE
🔨 Fix missing catch on `getPartnerDetails`

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -1327,7 +1327,7 @@ export default class Bot {
                     log.info(`Message sent to ${name} (${steamID64} - not friend): ${message}`);
                 })
                 .catch(err => {
-                    log.error(`Error while sending message to ${steamID64}`, err);
+                    log.error(`Error while getting ${steamID64} details`, err);
                 });
             return;
         }

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -1322,9 +1322,13 @@ export default class Bot {
         if (!friend) {
             // If not friend, we send message with chatMessage
             this.client.chatMessage(steamID, message);
-            void this.getPartnerDetails(steamID).then(name => {
-                log.info(`Message sent to ${name} (${steamID64} - not friend): ${message}`);
-            });
+            this.getPartnerDetails(steamID64)
+                .then(name => {
+                    log.info(`Message sent to ${name} (${steamID64} - not friend): ${message}`);
+                })
+                .catch(err => {
+                    log.error(`Error while sending message to ${steamID64}`, err);
+                });
             return;
         }
 


### PR DESCRIPTION
🚧 A failsafe from this error (crash):
![image](https://cdn.discordapp.com/attachments/666909760666468377/1007769441779585164/unknown.png)