### PR TITLE
✨ Add toggle option to show [𝐀𝐮𝐭𝐨𝐤𝐞𝐲𝐬]

### DIFF
--- a/src/classes/Commands/sub-classes/Options.ts
+++ b/src/classes/Commands/sub-classes/Options.ts
@@ -906,6 +906,10 @@ export default class OptionsCommands {
                     }
                 }
 
+                if (knownParams.details?.showAutokeys) {
+                    this.bot.listings.checkByPriceKey({ priceKey: '5021;6' });
+                }
+
                 if (steamID) {
                     return this.bot.sendMessage(steamID, msg);
                 } else {

--- a/src/classes/Listings.ts
+++ b/src/classes/Listings.ts
@@ -696,7 +696,11 @@ export default class Listings {
             details = replaceDetails(this.templates[key], entry, key)
                 .replace(/%keyPrice%/g, '')
                 .replace(/%uses%/g, '');
-            if (entry.name === 'Mann Co. Supply Crate Key' && this.bot.handler.autokeys.isEnabled) {
+            if (
+                entry.name === 'Mann Co. Supply Crate Key' &&
+                this.bot.handler.autokeys.isEnabled &&
+                opt.details.showAutokeys
+            ) {
                 details = '[𝐀𝐮𝐭𝐨𝐤𝐞𝐲𝐬] ' + details;
             }
             //

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -267,6 +267,7 @@ export const DEFAULTS: JsonOptions = {
     details: {
         buy: 'I am buying your %name% for %price%, I have %current_stock% / %max_stock%.',
         sell: 'I am selling my %name% for %price%, I am selling %amount_trade%.',
+        showAutokeys: true,
         showBoldText: {
             onPrice: false,
             onAmount: false,
@@ -1366,6 +1367,7 @@ interface NormalizePainted extends NormalizeOurOrTheir {
 interface Details {
     buy?: string;
     sell?: string;
+    showAutokeys?: boolean;
     showBoldText?: ShowBoldText;
     highValue?: ShowHighValue;
     uses?: UsesDetails;

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -1021,6 +1021,9 @@ export const optionsSchema: jsonschema.Schema = {
                     type: 'string',
                     maxLength: 180
                 },
+                showAutokeys: {
+                    type: 'boolean'
+                },
                 showBoldText: {
                     type: 'object',
                     properties: {
@@ -1124,7 +1127,7 @@ export const optionsSchema: jsonschema.Schema = {
                     additionalProperties: false
                 }
             },
-            required: ['buy', 'sell', 'showBoldText', 'highValue', 'uses'],
+            required: ['buy', 'sell', 'showAutokeys', 'showBoldText', 'highValue', 'uses'],
             additionalProperties: false
         },
         statistics: {


### PR DESCRIPTION
New option:
- `details.showAutokeys` (default: `true`).

Set this to `false` if you don't want the bot to add "[𝐀𝐮𝐭𝐨𝐤𝐞𝐲𝐬] " in front of the listing note if it's managed by the Autokeys feature.