### PR TITLE
✨Add way to wipe trade statistics while the bot is on

### DIFF
--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -243,6 +243,8 @@ export default class Commands {
                 this.status.statsDWCommand(steamID);
             } else if (command === 'itemstats' && (isAdmin || isWhitelisted)) {
                 void this.status.itemStatsCommand(steamID, message);
+            } else if (command == 'wipestats' && isAdmin) {
+                this.status.statsWipeCommand(steamID, message);
             } else if (command === 'inventory' && isAdmin) {
                 this.status.inventoryCommand(steamID);
             } else if (command === 'version' && (isAdmin || isWhitelisted)) {

--- a/src/classes/Commands/sub-classes/Help.ts
+++ b/src/classes/Commands/sub-classes/Help.ts
@@ -139,6 +139,7 @@ export default class HelpCommands {
                     [
                         '!stats - Get statistics for accepted trades 📊',
                         '!itemstats <item name|sku> - Get statistics for specific item (keys/weapons not supported) 📊',
+                        '!wipestats - Wipe statistics for accepted trades 🔥',
                         '!statsdw - Send statistics to Discord Webhook 📊',
                         "!inventory - Get the bot's current inventory spaces 🎒",
                         '!version - Get the TF2Autobot version that the bot is running'

--- a/src/classes/Commands/sub-classes/Status.ts
+++ b/src/classes/Commands/sub-classes/Status.ts
@@ -116,19 +116,24 @@ export default class StatusCommands {
 
         this.bot.sendMessage(steamID, '⚠️ Deleting all stats...');
 
-        const pollData: SteamTradeOfferManager.PollData = this.bot.manager.pollData;
+        try {
+            const pollData: SteamTradeOfferManager.PollData = this.bot.manager.pollData;
 
-        pollData.sent = {};
-        pollData.received = {};
-        pollData.timestamps = {};
-        pollData.offersSince = 0;
-        pollData.offerData = {};
+            pollData.sent = {};
+            pollData.received = {};
+            pollData.timestamps = {};
+            pollData.offersSince = 0;
+            pollData.offerData = {};
 
-        this.bot.trades.setPollData(pollData);
+            this.bot.trades.setPollData(pollData);
 
-        deletePollData(this.bot.handler.getPaths.files.dir);
+            deletePollData(this.bot.handler.getPaths.files.dir);
 
-        this.bot.sendMessage(steamID, '✅ All stats have been deleted.');
+            this.bot.sendMessage(steamID, '✅ All stats have been deleted.');
+        } catch (err) {
+            this.bot.sendMessage(steamID, `❌ Error while deleting stats: ${JSON.stringify(err)}`);
+        }
+        
     }
 
     inventoryCommand(steamID: SteamID): void {

--- a/src/lib/tools/polldata.ts
+++ b/src/lib/tools/polldata.ts
@@ -41,3 +41,11 @@ export default function loadPollData(dir: string) {
 
     return polldata;
 }
+
+export function deletePollData(dir: string) {
+    fs.readdirSync(dir)
+        .filter(name => name.includes('polldata'))
+        .forEach(name => {
+            fs.unlinkSync(dir + name);
+        });
+}


### PR DESCRIPTION
wipestats: wipe trade statistics via command

You can now use !wipestats to wipe the statistics returned by 
the !stats command, as opposed to having to stop the bot and
manually delete the polldata.json file.

Refs: https://discord.com/channels/664971400678998016/666909760666468377/1036824922430898186