### PR TITLE
➕ Add `!groups` command

### DIFF
--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -207,6 +207,8 @@ export default class Commands {
                 void this.pManager.partialPriceUpdateCommand(steamID, message);
             } else if (['getslots', 'listings'].includes(command) && isAdmin) {
                 void this.pManager.getSlotsCommand(steamID);
+            } else if (command === 'groups' && isAdmin) {
+                void this.pManager.getGroupsCommand(steamID);
             } else if (command === 'autoadd' && isAdmin) {
                 this.pManager.autoAddCommand(steamID, message);
             } else if (command === 'stopautoadd' && isAdmin) {

--- a/src/classes/Commands/sub-classes/Help.ts
+++ b/src/classes/Commands/sub-classes/Help.ts
@@ -86,7 +86,8 @@ export default class HelpCommands {
                         '!getAll [limit=<number>] - Get a list of all items exist in your pricelist. Set limit=-1 to show all',
                         '!find <Listing-parameters>=<value>[&limit=<value>] - Get the list of filtered items detail based on the parameters 🔍',
                         '!ppu [limit=<number>] - Get a list of items that is currently has Partial Price Update enabled',
-                        '!getSlots or !listings - Get current used listings slot per cap count.'
+                        '!getSlots or !listings - Get current used listings slot per cap count.',
+                        '!groups - Get a list of groups in your pricelist 📜'
                     ].join('\n- ')
             );
 

--- a/src/classes/Commands/sub-classes/PricelistManager.ts
+++ b/src/classes/Commands/sub-classes/PricelistManager.ts
@@ -1904,6 +1904,30 @@ export default class PricelistManagerCommands {
         );
     }
 
+    getGroupsCommand(steamID: SteamID): void {
+        const pricelist = this.bot.pricelist.getPrices;
+        if (Object.keys(pricelist).length === 0) {
+            return this.bot.sendMessage(steamID, '❌ Your pricelist is empty.');
+        }
+
+        const groups = new Map<string, number>();
+        for (const priceKey of Object.keys(pricelist)) {
+            const entry = pricelist[priceKey];
+            const group = entry.group;
+            if (!groups.has(group)) {
+                groups.set(group, 0);
+            }
+            groups.set(group, groups.get(group) + 1);
+        }
+
+        let answer = `You have ${groups.size} groups in total:\n`;
+        [...groups.keys()].forEach((group, i) => {
+            answer += `${i + 1}. ${group} (${groups.get(group)} entries)\n`;
+        });
+
+        return this.bot.sendMessage(steamID, answer);
+    }
+
     getCommand(steamID: SteamID, message: string): void {
         const params = CommandParser.parseParams(CommandParser.removeCommand(removeLinkProtocol(message)));
         let sku = params.sku as string;

--- a/src/classes/Commands/sub-classes/PricelistManager.ts
+++ b/src/classes/Commands/sub-classes/PricelistManager.ts
@@ -1922,7 +1922,8 @@ export default class PricelistManagerCommands {
 
         let answer = `You have ${groups.size} groups in total:\n`;
         [...groups.keys()].forEach((group, i) => {
-            answer += `${i + 1}. ${group} (${groups.get(group)} entries)\n`;
+            const amount = groups.get(group);
+            answer += `${i + 1}. ${group} (${amount} ${amount === 1 ? 'entry' : 'entries'})\n`;
         });
 
         return this.bot.sendMessage(steamID, answer);


### PR DESCRIPTION
This command was requested a couple of times, so I decided to implement it.

How to use: as an admin, send `!groups` to get a list of groups in your bot's pricelist.