### PR TITLE
🔨 Make sure to also reset the `statistics` options when using the `!wipestats` command

### DIFF
--- a/src/classes/Commands/sub-classes/Status.ts
+++ b/src/classes/Commands/sub-classes/Status.ts
@@ -130,6 +130,11 @@ export default class StatusCommands {
             deletePollData(this.bot.handler.getPaths.files.dir);
 
             this.bot.sendMessage(steamID, '✅ All stats have been deleted.');
+
+            this.bot.handler.commands.useUpdateOptionsCommand(
+                steamID,
+                '!config statistics.lastTotalTrades=0&statistics.startingTimeInUnix=0&statistics.lastTotalProfitMadeInRef=0&statistics.lastTotalProfitOverpayInRef=0&statistics.profitDataSinceInUnix=0'
+            );
         } catch (err) {
             this.bot.sendMessage(steamID, `❌ Error while deleting stats: ${JSON.stringify(err)}`);
         }


### PR DESCRIPTION
A little addition to the #1405.