### PR TITLE
fix: 🐛 "Voices From Below" renamed to "Voices from Below"

### DIFF
--- a/.example/options.json
+++ b/.example/options.json
@@ -787,7 +787,7 @@
             "Chromatic Corruption": "CC 🪀",
             "Spectral Spectrum": "Spec 🔵🔴",
             "Sinister Staining": "Sin 🍈",
-            "Voices From Below": "VFB 🗣️",
+            "Voices from Below": "VFB 🗣️",
             "Team Spirit Footprints": "TS-FP 🔵🔴",
             "Gangreen Footprints": "GG-FP 🟡",
             "Corpse Gray Footprints": "CG-FP 👽",

--- a/.example/options.json
+++ b/.example/options.json
@@ -787,7 +787,7 @@
             "Chromatic Corruption": "CC 🪀",
             "Spectral Spectrum": "Spec 🔵🔴",
             "Sinister Staining": "Sin 🍈",
-            "Voices from Below": "VFB 🗣️",
+            "Voices From Below": "VFB 🗣️",
             "Team Spirit Footprints": "TS-FP 🔵🔴",
             "Gangreen Footprints": "GG-FP 🟡",
             "Corpse Gray Footprints": "CG-FP 👽",

--- a/src/classes/Inventory.ts
+++ b/src/classes/Inventory.ts
@@ -522,8 +522,8 @@ export default class Inventory {
                 content.value.endsWith('(spell only active during event)') &&
                 content.color === '7ea9d1'
             ) {
-                // Example: "Halloween: Voices From Below (spell only active during event)"
-                // where "Voices From Below" is the spell name.
+                // Example: "Halloween: Voices from Below (spell only active during event)"
+                // where "Voices from Below" is the spell name.
                 // Color of this description must be rgb(126, 169, 209) or 7ea9d1
                 // https://www.spycolor.com/7ea9d1#
                 // Get the spell name

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -2158,7 +2158,7 @@ export interface JsonOptions {
  *
  */
 export interface DeprecatedJsonOptions extends JsonOptions {
-    detailsExtra?: DeprecatedDetailsExtra
+    detailsExtra?: DeprecatedDetailsExtra;
 }
 
 export default interface Options extends JsonOptions {
@@ -2453,9 +2453,9 @@ function replaceOldProperties(options: DeprecatedJsonOptions): boolean {
     }
 
     // "Voices From Below" renamed to "Voices from Below"
-    if(options.detailsExtra?.spells?.["Voices From Below"] !== undefined) {
-        options.detailsExtra.spells["Voices from Below"] = options.detailsExtra?.spells?.["Voices From Below"];
-        delete options.detailsExtra.spells["Voices From Below"];
+    if (options.detailsExtra?.spells?.['Voices From Below'] !== undefined) {
+        options.detailsExtra.spells['Voices from Below'] = options.detailsExtra?.spells?.['Voices From Below'];
+        delete options.detailsExtra.spells['Voices From Below'];
         isChanged = true;
     }
 

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -846,7 +846,7 @@ export const DEFAULTS: JsonOptions = {
             'Chromatic Corruption': 'CC 🪀',
             'Spectral Spectrum': 'Spec 🔵🔴',
             'Sinister Staining': 'Sin 🍈',
-            'Voices From Below': 'VFB 🗣️',
+            'Voices from Below': 'VFB 🗣️',
             'Team Spirit Footprints': 'TS-FP 🔵🔴',
             'Gangreen Footprints': 'GG-FP 🟡',
             'Corpse Gray Footprints': 'CG-FP 👽',
@@ -1952,13 +1952,18 @@ interface DetailsExtra {
     strangeParts?: StrangeParts;
 }
 
+/** bridge Deprecated DetailsExtra values */
+interface DeprecatedDetailsExtra extends DetailsExtra {
+    spells?: DeprecatedSpells;
+}
+
 interface Spells {
     'Putrescent Pigmentation'?: string;
     'Die Job'?: string;
     'Chromatic Corruption'?: string;
     'Spectral Spectrum'?: string;
     'Sinister Staining'?: string;
-    'Voices From Below'?: string;
+    'Voices from Below'?: string;
     'Team Spirit Footprints'?: string;
     'Gangreen Footprints'?: string;
     'Corpse Gray Footprints'?: string;
@@ -1969,6 +1974,11 @@ interface Spells {
     Exorcism?: string;
     'Pumpkin Bombs'?: string;
     'Halloween Fire'?: string;
+}
+
+/** these were renamed and are only used for migration */
+interface DeprecatedSpells extends Spells {
+    'Voices From Below'?: string;
 }
 
 interface Sheens {
@@ -2141,6 +2151,16 @@ export interface JsonOptions {
     detailsExtra?: DetailsExtra;
 }
 
+/** old options that are migrated out of current JsonOptions
+ *
+ * this structure are all the current options with anything
+ * that has been migrated out
+ *
+ */
+export interface DeprecatedJsonOptions extends JsonOptions {
+    detailsExtra?: DeprecatedDetailsExtra
+}
+
 export default interface Options extends JsonOptions {
     steamAccountName?: string;
     steamPassword?: string;
@@ -2237,7 +2257,7 @@ function loadJsonOptions(optionsPath: string, options?: Options): JsonOptions {
     try {
         const rawOptions = readFileSync(optionsPath, { encoding: 'utf8' });
         try {
-            const parsedRaw = JSON.parse(rawOptions) as JsonOptions;
+            const parsedRaw = JSON.parse(rawOptions) as DeprecatedJsonOptions;
             if (replaceOldProperties(parsedRaw)) {
                 writeFileSync(optionsPath, JSON.stringify(parsedRaw, null, 4), { encoding: 'utf8' });
             }
@@ -2284,7 +2304,8 @@ export function removeCliOptions(incomingOptions: Options): void {
     }
 }
 
-function replaceOldProperties(options: Options): boolean {
+/** take a JsonOptions that had potentially deprecated options and update appropriately */
+function replaceOldProperties(options: DeprecatedJsonOptions): boolean {
     // Automatically replace old properties
     let isChanged = false;
 
@@ -2428,6 +2449,13 @@ function replaceOldProperties(options: Options): boolean {
         //@ts-ignore
         delete options.customMessage.iDontKnowWhatYouMean;
         options.customMessage['commandNotFound'] = '';
+        isChanged = true;
+    }
+
+    // "Voices From Below" renamed to "Voices from Below"
+    if(options.detailsExtra?.spells?.["Voices From Below"] !== undefined) {
+        options.detailsExtra.spells["Voices from Below"] = options.detailsExtra?.spells?.["Voices From Below"];
+        delete options.detailsExtra.spells["Voices From Below"];
         isChanged = true;
     }
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -60,7 +60,7 @@ export const spellsData: { [name: string]: string } = {
     'Putrescent Pigmentation': 's-1004-2',
     'Spectral Spectrum': 's-1004-3',
     'Sinister Staining': 's-1004-4',
-    'Voices From Below': 's-1006-1',
+    'Voices from Below': 's-1006-1',
     'Pumpkin Bombs': 's-1007-1',
     'Halloween Fire': 's-1008-1',
     Exorcism: 's-1009-1'

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -2246,7 +2246,7 @@ export const optionsSchema: jsonschema.Schema = {
                         'Sinister Staining': {
                             type: 'string'
                         },
-                        'Voices From Below': {
+                        'Voices from Below': {
                             type: 'string'
                         },
                         'Team Spirit Footprints': {
@@ -2286,7 +2286,7 @@ export const optionsSchema: jsonschema.Schema = {
                         'Chromatic Corruption',
                         'Spectral Spectrum',
                         'Sinister Staining',
-                        'Voices From Below',
+                        'Voices from Below',
                         'Team Spirit Footprints',
                         'Gangreen Footprints',
                         'Corpse Gray Footprints',


### PR DESCRIPTION
Per the [March 30th patch](https://wiki.teamfortress.com/wiki/March_30,_2023_Patch) the inventory now returns Voices from Below

Also added DeprecatedJsonOptions to allow migration of options in predicable way.

This fixes starting you bot and getting the following error because Voices From Below returns an "undefined" key with no high value type.

>  {"level":"error","message":"TF2Autobot failed to start properly, this is most likely a temporary error. See the log:\r\npackage.version: 5.6.0; node: v16.13.2 win32 x64}\r\nStack trace:\r\nTypeError: Cannot read properties of undefined (reading 'replace')\n    at c:\\tf2autobot\\dist\\classes\\Listings.js:463:61\n    at Array.forEach (<anonymous>)\n    at Listings.getDetails (c:\\tf2autobot\\dist\\classes\\Listings.js:431:37)\n    at Listings.checkByPriceKey (c:\\tf2autobot\\dist\\classes\\Listings.js:228:35)\n    at Immediate.<anonymous> (c:\\tf2autobot\\dist\\classes\\Listings.js:325:30)\n    at processImmediate (node:internal/timers:464:21)\r\nBot has been up for 31 seconds.","timestamp":"2023-04-01T14:54:38.907Z"}
{"err":"uncaughtException","level":"debug","message":"Shutdown has been initialized, stopping...","timestamp":"2023-04-01T14:54:38.908Z"}