### PR TITLE
✨ add `!withdrawAll` command

### DIFF
--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -1161,7 +1161,7 @@ export default class Commands {
 
         const params = CommandParser.parseParams(CommandParser.removeCommand(removeLinkProtocol(message)));
 
-        const max = typeof params.max === 'number' ? params.max : 1;
+        const max = typeof params.max === 'number' ? params.max : Infinity;
         if (!Number.isInteger(max)) {
             return this.bot.sendMessage(steamID, `❌ max should only be an integer.`);
         }

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -1162,7 +1162,7 @@ export default class Commands {
         const params = CommandParser.parseParams(CommandParser.removeCommand(removeLinkProtocol(message)));
 
         const max = typeof params.max === 'number' ? params.max : Infinity;
-        if (!Number.isInteger(max)) {
+        if (params.max && !Number.isInteger(max)) {
             return this.bot.sendMessage(steamID, `❌ max should only be an integer.`);
         }
 

--- a/src/classes/Commands/Commands.ts
+++ b/src/classes/Commands/Commands.ts
@@ -1176,34 +1176,16 @@ export default class Commands {
         const dict = this.bot.inventoryManager.getInventory.getItems;
         const clonedDict = Object.assign({}, dict);
 
-        const weaponsAsCurrency = this.bot.options.miscSettings.weaponsAsCurrency;
+        if (withGroup) {
+            for (const sku in clonedDict) {
+                if (!Object.prototype.hasOwnProperty.call(clonedDict, sku)) {
+                    continue;
+                }
 
-        const pureAndWeapons = weaponsAsCurrency.enable
-            ? ['5021;6', '5000;6', '5001;6', '5002;6'].concat(
-                  weaponsAsCurrency.withUncraft
-                      ? this.bot.craftWeapons.concat(this.bot.uncraftWeapons)
-                      : this.bot.craftWeapons
-              )
-            : ['5021;6', '5000;6', '5001;6', '5002;6'];
-
-        for (const sku in clonedDict) {
-            if (!Object.prototype.hasOwnProperty.call(clonedDict, sku)) {
-                continue;
-            }
-
-            let isWithinGroup = false;
-
-            if (withGroup) {
                 if (withGroup !== this.bot.pricelist.getPrice({ priceKey: sku })?.group) {
                     delete clonedDict[sku];
                     continue;
                 }
-                isWithinGroup = true;
-            }
-
-            if (pureAndWeapons.includes(sku) && !isWithinGroup) {
-                delete clonedDict[sku];
-                continue;
             }
         }
 

--- a/src/classes/Commands/sub-classes/Help.ts
+++ b/src/classes/Commands/sub-classes/Help.ts
@@ -99,6 +99,7 @@ export default class HelpCommands {
                     [
                         `${prefix}deposit (sku|name|defindex)=<a>&amount=<number> - Deposit items.`,
                         `withdraw (sku|name|defindex)=<a>&amount=<number> - Withdraw items.`,
+                        `withdrawAll [withgroup=<itemgroup>[&&max=<number>]] - Withdraw all items.`,
                         `withdrawMptf [max=<number>] - [Exclusive Marketplace.tf Sellers] Withdraw items that does not exist on Marketplace.tf Dashboard items.`,
                         `expand craftable=(true|false) - Use Backpack Expanders to increase the bot's inventory limit.`,
                         `use (sku|assetid)=<a> - Use an item (such as Gift-Stuffed Stocking 2020 - sku: 5923;6;untradable).`,


### PR DESCRIPTION
On-demand command. Use this command to withdraw all items from your bot.

Optional Parameters:
- `max`: default is Infinity. If the amount of item x in your bot inventory > max, then the bot will only add item x to withdraw until max amount you set.
- `withgroup`: no default value. Use this if you want to withdraw only a certain group in your pricelist.