### PR TITLE
🐛 fix undefined "Voices from Below" spell

### DIFF
--- a/src/classes/Inventory.ts
+++ b/src/classes/Inventory.ts
@@ -532,7 +532,7 @@ export default class Inventory {
                 const spellName = content.value.substring(10, content.value.length - 32).trim();
 
                 // push for storage, example: s-1000
-                s[spellsData[spellName]] =
+                s[spellsData[spellName.replace('From', 'from')]] =
                     (this.spellsExceptionNotEmpty // check if exception not empty
                         ? !this.spellsExceptionSkus.some(exSku => sku.includes(exSku)) // if this true, make it false
                         : true) && this.spellsOptions.includes(spellName.toLowerCase());


### PR DESCRIPTION
Not sure why the bot sometimes still uses the old name instead of the new one, so this should replace the "F" to "f", and prevent it from being undefined.

Thanks @joekiller for the report.
![image](https://github.com/TF2Autobot/tf2autobot/assets/47635037/638554cb-b8d8-474b-b2aa-907f55532568)
