### PR TITLE
Fix broken halt command

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -1,5 +1,6 @@
 import SteamID from 'steamid';
-import SteamUser, { EPersonaState, EResult } from 'steam-user';
+import SteamUser from 'steam-user';
+import { EResult, EPersonaState } from 'steam-user';
 import TradeOfferManager, { CustomError, EconItem } from '@tf2autobot/tradeoffer-manager';
 import SteamCommunity from '@tf2autobot/steamcommunity';
 import SteamTotp from 'steam-totp';


### PR DESCRIPTION
This simple and innocent-looking change is what causes the `!halt` and `!unhalt` commands to break.

![image](https://user-images.githubusercontent.com/47635037/248083488-0a73fb67-accb-432e-a9ee-f78b475ede3d.png)