### PR TITLE
Downgrade `ws` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
                 "winston": "^3.8.2",
                 "winston-daily-rotate-file": "^4.7.1",
                 "write-file-atomic": "^5.0.0",
-                "ws": "^8.13.0"
+                "ws": "^7.5.9"
             },
             "devDependencies": {
                 "@babel/preset-typescript": "^7.22.5",
@@ -836,6 +836,26 @@
             },
             "engines": {
                 "node": ">=16.9.0"
+            }
+        },
+        "node_modules/@discordjs/ws/node_modules/ws": {
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@doctormckay/stdlib": {
@@ -2083,26 +2103,6 @@
             "version": "6.4.9",
             "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
             "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
-        },
-        "node_modules/@pm2/js-api/node_modules/ws": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/@pm2/pm2-version-check": {
             "version": "1.0.4",
@@ -4442,6 +4442,26 @@
             },
             "engines": {
                 "node": ">=16.9.0"
+            }
+        },
+        "node_modules/discord.js/node_modules/ws": {
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/doctrine": {
@@ -11536,15 +11556,15 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "version": "7.5.9",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=8.3.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
+                "utf-8-validate": "^5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "winston": "^3.8.2",
         "winston-daily-rotate-file": "^4.7.1",
         "write-file-atomic": "^5.0.0",
-        "ws": "^8.13.0"
+        "ws": "^7.5.9"
     },
     "devDependencies": {
         "@babel/preset-typescript": "^7.22.5",


### PR DESCRIPTION
Apparently, the latest version of `ws` (or any version 8) still crashes the bot whenever the connection to prices.tf websocket failed. Downgrading to the latest version 7 should help solve this problem.

![image](https://cdn.discordapp.com/attachments/666909760666468377/1121153208329453608/image.png)