### PR TITLE
An option to limit pricelist rewrite

### DIFF
--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -129,6 +129,9 @@ export const DEFAULTS: JsonOptions = {
         },
         priceAge: {
             maxInSeconds: 28800
+        },
+        rewriteFile: {
+            count: 1
         }
     },
 
@@ -1284,6 +1287,7 @@ interface Pricelist {
     autoAddInvalidUnusual?: OnlyEnable;
     autoAddPaintedItems?: OnlyEnable;
     priceAge?: PriceAge;
+    rewriteFile?: RewriteFile;
 }
 
 interface PartialPriceUpdate extends OnlyEnable {
@@ -1293,6 +1297,10 @@ interface PartialPriceUpdate extends OnlyEnable {
 
 interface PriceAge {
     maxInSeconds?: number;
+}
+
+interface RewriteFile {
+    count: number;
 }
 
 // ------------ Bypass ------------

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -230,6 +230,8 @@ export default class Pricelist extends EventEmitter {
 
     autoResetPartialPriceBulk: string[] = [];
 
+    private priceChangeCounter = 0;
+
     assetidInPricelist: AssetidInPricelist = {};
 
     checkAssetidInPricelistInterval: NodeJS.Timeout;
@@ -1337,7 +1339,12 @@ export default class Pricelist extends EventEmitter {
 
     private priceChanged(priceKey: string | number, entry: Entry): void {
         this.emit('price', priceKey, entry);
-        this.emit('pricelist', this.prices);
+
+        if (++this.priceChangeCounter % 100 === 0) {
+            this.emit('pricelist', this.prices);
+
+            this.priceChangeCounter = 0;
+        }
     }
 
     private get getOld(): PricesObject {

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -1340,7 +1340,8 @@ export default class Pricelist extends EventEmitter {
     private priceChanged(priceKey: string | number, entry: Entry): void {
         this.emit('price', priceKey, entry);
 
-        if (++this.priceChangeCounter % 100 === 0) {
+        if (++this.priceChangeCounter % this.options.pricelist.rewriteFile.count === 0) {
+            // reference: https://github.com/Hhanuska/tf2autobot/commit/54c408936cc923d56d525f01726c042a84e1ec75
             this.emit('pricelist', this.prices);
 
             this.priceChangeCounter = 0;

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -693,6 +693,17 @@ export const optionsSchema: jsonschema.Schema = {
                     },
                     required: ['maxInSeconds'],
                     additionalProperties: false
+                },
+                rewriteFile: {
+                    type: 'object',
+                    properties: {
+                        count: {
+                            type: 'integer',
+                            minimum: 1
+                        }
+                    },
+                    required: ['count'],
+                    additionalProperties: false
                 }
             },
             required: [
@@ -703,7 +714,8 @@ export const optionsSchema: jsonschema.Schema = {
                 'autoAddInvalidItems',
                 'autoAddInvalidUnusual',
                 'autoAddPaintedItems',
-                'priceAge'
+                'priceAge',
+                'rewriteFile'
             ],
             additionalProperties: false
         },


### PR DESCRIPTION
![image](https://github.com/TF2Autobot/tf2autobot/assets/47635037/d9a61c69-807b-4516-b126-e213cbdd866f)

Use case:
- High-frequency custom pricer might need to set the `rewriteFile.count` option to 100 or more.
- Bot with a lot of items in the pricelist (with `autoprice` set to `true`) that is experiencing slow performance: can try another value other than the default (1).

Reference:
- https://github.com/Hhanuska/tf2autobot/commit/54c408936cc923d56d525f01726c042a84e1ec75
