### PR TITLE
fix sell commands not working for generic unusuals

### DIFF
--- a/src/classes/Carts/UserCart.ts
+++ b/src/classes/Carts/UserCart.ts
@@ -533,7 +533,7 @@ export default class UserCart extends Cart {
             let theirAssetids: string[];
             let amount = this.getTheirCount(sku);
             if (findByPartialSku) {
-                theirAssetids = theirInventory.findByPartialSku(sku, true, elevatedStrange);
+                theirAssetids = theirInventory.findByPartialSku(sku, elevatedStrange);
                 if (theirAssetids.length > 0) {
                     sku = theirInventory.findByAssetid(theirAssetids[0]);
                 }
@@ -777,7 +777,7 @@ export default class UserCart extends Cart {
             let assetids: string[];
             const amount = this.their[sku];
             if (findByPartialSku) {
-                assetids = theirInventory.findByPartialSku(sku, true, elevatedStrange);
+                assetids = theirInventory.findByPartialSku(sku, elevatedStrange);
             } else {
                 assetids = theirInventory.findBySKU(sku, true);
             }

--- a/src/classes/Carts/UserCart.ts
+++ b/src/classes/Carts/UserCart.ts
@@ -514,15 +514,34 @@ export default class UserCart extends Cart {
         };
 
         // Add their items
-        for (const sku in this.their) {
+        for (let sku in this.their) {
             if (!Object.prototype.hasOwnProperty.call(this.their, sku)) {
                 continue;
             }
 
-            let alteredMessage: string;
+            let findByPartialSku = false;
+            let elevatedStrange = false;
+            const item_object = SKU.fromString(sku);
+            if (item_object.quality == 5 && !item_object.effect) {
+                log.debug('Generic Unusual in their cart, finding by partial sku');
+                findByPartialSku = true;
+                if (item_object.quality2 == 11) {
+                    elevatedStrange = true;
+                }
+            }
 
+            let theirAssetids: string[];
             let amount = this.getTheirCount(sku);
-            const theirAssetids = theirInventory.findBySKU(sku, true);
+            if (findByPartialSku) {
+                theirAssetids = theirInventory.findByPartialSku(sku, true, elevatedStrange);
+                if (theirAssetids.length > 0) {
+                    sku = theirInventory.findByAssetid(theirAssetids[0]);
+                }
+            } else {
+                theirAssetids = theirInventory.findBySKU(sku, true);
+            }
+
+            let alteredMessage: string;
             const theirAssetidsCount = theirAssetids.length;
 
             if (amount > theirAssetidsCount) {
@@ -745,8 +764,23 @@ export default class UserCart extends Cart {
                 continue;
             }
 
+            const item_object = SKU.fromString(sku);
+            let findByPartialSku = false;
+            let elevatedStrange = false;
+            if (item_object.quality == 5 && !item_object.effect) {
+                findByPartialSku = true;
+                if (item_object.quality2 == 11) {
+                    elevatedStrange = true;
+                }
+            }
+
+            let assetids: string[];
             const amount = this.their[sku];
-            let assetids = theirInventory.findBySKU(sku, true);
+            if (findByPartialSku) {
+                assetids = theirInventory.findByPartialSku(sku, true, elevatedStrange);
+            } else {
+                assetids = theirInventory.findBySKU(sku, true);
+            }
 
             const addToDupeCheckList =
                 this.bot.pricelist

--- a/src/classes/Inventory.ts
+++ b/src/classes/Inventory.ts
@@ -196,7 +196,7 @@ export default class Inventory {
         return nonTradable.concat(tradable).slice(0);
     }
 
-    findByPartialSku(partialSku: string, tradableOnly = true, elevatedStrange = false): string[] {
+    findByPartialSku(partialSku: string, elevatedStrange = false): string[] {
         const matchingSkus: string[] = [];
 
         if (elevatedStrange) {
@@ -207,27 +207,10 @@ export default class Inventory {
                     matchingSkus.push(...this.tradable[sku].map(item => item?.id));
                 }
             }
-
-            if (!tradableOnly) {
-                for (const sku in this.nonTradable) {
-                    if (sku.startsWith(partialSku) && sku.includes(';strange')) {
-                        matchingSkus.push(...this.nonTradable[sku].map(item => item?.id));
-                    }
-                }
-            }
-
         } else {
             for (const sku in this.tradable) {
                 if (sku.startsWith(partialSku)) {
                     matchingSkus.push(...this.tradable[sku].map(item => item?.id));
-                }
-            }
-
-            if (!tradableOnly) {
-                for (const sku in this.nonTradable) {
-                    if (sku.startsWith(partialSku)) {
-                        matchingSkus.push(...this.nonTradable[sku].map(item => item?.id));
-                    }
                 }
             }
         }

--- a/src/classes/Inventory.ts
+++ b/src/classes/Inventory.ts
@@ -6,6 +6,7 @@ import { HighValue } from './Options';
 import Bot from './Bot';
 import { noiseMakers, spellsData, killstreakersData, sheensData } from '../lib/data';
 import Pricelist from './Pricelist';
+import log from '../lib/logger';
 
 export default class Inventory {
     private readonly steamID: SteamID;
@@ -193,6 +194,44 @@ export default class Inventory {
         const nonTradable = (this.nonTradable[sku] || []).map(item => item?.id);
 
         return nonTradable.concat(tradable).slice(0);
+    }
+
+    findByPartialSku(partialSku: string, tradableOnly = true, elevatedStrange = false): string[] {
+        const matchingSkus: string[] = [];
+
+        if (elevatedStrange) {
+            partialSku = partialSku.replace(';strange', '');
+
+            for (const sku in this.tradable) {
+                if (sku.startsWith(partialSku) && sku.includes(';strange')) {
+                    matchingSkus.push(...this.tradable[sku].map(item => item?.id));
+                }
+            }
+
+            if (!tradableOnly) {
+                for (const sku in this.nonTradable) {
+                    if (sku.startsWith(partialSku) && sku.includes(';strange')) {
+                        matchingSkus.push(...this.nonTradable[sku].map(item => item?.id));
+                    }
+                }
+            }
+
+        } else {
+            for (const sku in this.tradable) {
+                if (sku.startsWith(partialSku)) {
+                    matchingSkus.push(...this.tradable[sku].map(item => item?.id));
+                }
+            }
+
+            if (!tradableOnly) {
+                for (const sku in this.nonTradable) {
+                    if (sku.startsWith(partialSku)) {
+                        matchingSkus.push(...this.nonTradable[sku].map(item => item?.id));
+                    }
+                }
+            }
+        }
+        return matchingSkus.slice(0);
     }
 
     getAmount({


### PR DESCRIPTION
fixes commands like !sell (generic unusual).

add findByPartialSku() for Inventory.ts which is called when an unusual object has no effect. Is called when searching for generic unusuals in other player's inventory.

fixes: https://github.com/TF2Autobot/tf2autobot/issues/1682