### PR TITLE
Fixed handling one word item name on buy/sell

### DIFF
--- a/src/classes/Commands/functions/utils.ts
+++ b/src/classes/Commands/functions/utils.ts
@@ -18,21 +18,9 @@ export function getItemAndAmount(
     prefix: string,
     from?: 'buy' | 'sell' | 'buycart' | 'sellcart'
 ): { match: Entry; priceKey: string; amount: number } | null {
-    let name = removeLinkProtocol(message);
-    let amount = 1;
-    const args = name.split(' ');
-    if (/^[-]?\d+$/.test(args[0]) && args.length > 2) {
-        // Check if the first part of the name is a number, if so, then that is the amount the user wants to trade
-        amount = parseInt(args[0]);
-        name = name.replace(amount.toString(), '').trim();
-    } else if (Pricelist.isAssetId(args[0]) && args.length === 1) {
-        // Check if the only parameter is an assetid
-        name = args[0];
-    }
-
-    if (1 > amount) {
-        amount = 1;
-    }
+    const parsedMessage = parseItemAndAmountFromMessage(message);
+    const name = parsedMessage.name;
+    let amount = parsedMessage.amount;
 
     if (['!price', '!sellcart', '!buycart', '!sell', '!buy', '!pc', '!s', '!b'].includes(name)) {
         bot.sendMessage(
@@ -208,6 +196,26 @@ export function getItemAndAmount(
         priceKey: priceKey,
         match: match
     };
+}
+
+export function parseItemAndAmountFromMessage(message: string): { name: string; amount: number } {
+    let name = removeLinkProtocol(message);
+    let amount = 1;
+    const args = name.split(' ');
+    if (/^[-]?\d+$/.test(args[0]) && args.length > 1) {
+        // Check if the first part of the name is a number, if so, then that is the amount the user wants to trade
+        amount = parseInt(args[0]);
+        name = name.replace(amount.toString(), '').trim();
+    } else if (Pricelist.isAssetId(args[0]) && args.length === 1) {
+        // Check if the only parameter is an assetid
+        name = args[0];
+    }
+
+    if (1 > amount) {
+        amount = 1;
+    }
+
+    return { name: name, amount: amount };
 }
 
 export function getItemFromParams(

--- a/src/classes/__tests__/Commands/functions/utils.ts
+++ b/src/classes/__tests__/Commands/functions/utils.ts
@@ -1,0 +1,21 @@
+import { parseItemAndAmountFromMessage } from '../../../Commands/functions/utils';
+
+it('can parse one word item names', () => {
+    let messageArgs = '5 Maul';
+    let parsedMessage = parseItemAndAmountFromMessage(messageArgs);
+    expect(parsedMessage).toEqual({ name: 'Maul', amount: 5 });
+
+    messageArgs = 'Maul';
+    parsedMessage = parseItemAndAmountFromMessage(messageArgs);
+    expect(parsedMessage).toEqual({ name: 'Maul', amount: 1 });
+});
+
+it('can parse multiple word item names', () => {
+    let messageArgs = '5 Nostromo Napalmer';
+    let parsedMessage = parseItemAndAmountFromMessage(messageArgs);
+    expect(parsedMessage).toEqual({ name: 'Nostromo Napalmer', amount: 5 });
+
+    messageArgs = 'Nostromo Napalmer';
+    parsedMessage = parseItemAndAmountFromMessage(messageArgs);
+    expect(parsedMessage).toEqual({ name: 'Nostromo Napalmer', amount: 1 });
+});


### PR DESCRIPTION
Fixed invalid handling one word item names (e.g. `Maul`) on `!buy` or `!sell`. As of now, it parses the item name from `!buy 5 Maul` as `5 Maul` instead of `Maul`.

Basically, the change is:
```typescript
if (... && args.length > 2) { ... }
```
to
```typescript
if (... && args.length > 1) { ... }
```
, but for testing purposes parsing logic moved to a separate function `parseItemAndAmountFromMessage`.

Apparently, the function `getItemAndAmount(...)` used to accept message with command included, but now all references use it as follows:
`getItemAndAmount(steamID, CommandParser.removeCommand(message), this.bot, prefix);`
, so the command is not included anymore.

The syntax below used instead of unpacking to make linter happy:
```typescript
const name = parsedMessage.name;
let amount = parsedMessage.amount;
```

Fixes #1692 