### PR TITLE
Fix logic for finding generic unusual items in cart

### DIFF
--- a/src/classes/Carts/UserCart.ts
+++ b/src/classes/Carts/UserCart.ts
@@ -522,7 +522,7 @@ export default class UserCart extends Cart {
             let findByPartialSku = false;
             let elevatedStrange = false;
             const item_object = SKU.fromString(sku);
-            if (item_object.quality == 5 && !item_object.effect) {
+            if (item_object.quality == 5 && !item_object.effect && item_object.craftable) {
                 log.debug('Generic Unusual in their cart, finding by partial sku');
                 findByPartialSku = true;
                 if (item_object.quality2 == 11) {
@@ -767,7 +767,7 @@ export default class UserCart extends Cart {
             const item_object = SKU.fromString(sku);
             let findByPartialSku = false;
             let elevatedStrange = false;
-            if (item_object.quality == 5 && !item_object.effect) {
+            if (item_object.quality == 5 && !item_object.effect && item_object.craftable) {
                 findByPartialSku = true;
                 if (item_object.quality2 == 11) {
                     elevatedStrange = true;


### PR DESCRIPTION
Distinguishes generics from taunt unusualifiers with a craftability check when running the !sell command.

Example unusualifer sku - 9258;5;uncraftable;td-1109
Example generic sku - 31128;5