### PR TITLE
fix: remove refresh token on access denied

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -1405,7 +1405,7 @@ export default class Bot {
                     resolve(null);
                 };
 
-                const errorEvent = (err): void => {
+                const errorEvent = (err: CustomError): void => {
                     gotEvent();
 
                     this.client.removeListener('loggedOn', loggedOnEvent);
@@ -1413,7 +1413,14 @@ export default class Bot {
 
                     log.error('Failed to sign in to Steam: ', err);
 
-                    reject(err);
+                    if (err.eresult === EResult.AccessDenied) {
+                        // Access denied during login
+                        this.deleteRefreshToken().finally(() => {
+                            reject(err);
+                        });
+                    } else {
+                        reject(err);
+                    }
                 };
 
                 const timeout = setTimeout(() => {


### PR DESCRIPTION
When logging in the bot removes error listeners and only adds them back when successfully logged in. This means that if you first start the bot and get the accessdenied error, then the bot will keep crashing because it keeps trying to sign in using the invalid refresh token.

Bot registers handler for error events on the client:

https://github.com/TF2Autobot/tf2autobot/blob/133b3da1d3e96a66fe93c2d698d3d1d02ccf5bea/src/classes/Bot.ts#L846
https://github.com/TF2Autobot/tf2autobot/blob/133b3da1d3e96a66fe93c2d698d3d1d02ccf5bea/src/classes/Bot.ts#L1616-L1644

Bot removes error listeners when attempting to log in:

https://github.com/TF2Autobot/tf2autobot/blob/133b3da1d3e96a66fe93c2d698d3d1d02ccf5bea/src/classes/Bot.ts#L1389-L1397

Bot does not handle access denied errors in the login error handler:

https://github.com/TF2Autobot/tf2autobot/blob/133b3da1d3e96a66fe93c2d698d3d1d02ccf5bea/src/classes/Bot.ts#L1408-L1417