### PR TITLE
Include package-lock.json in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,3 @@ dist/**/*
 node_modules/**/*
 .env
 npm-debug.log
-package-lock.json
-yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="Renoki Co. <alex@renoki.org>"
 
 COPY . /app
 
-RUN npm install typescript@latest pm2 -g && \
+RUN npm install pm2 -g && \
     cd /app && \
     npm install && \
     npm run build && \


### PR DESCRIPTION
Fixes an issue where the latest version of typescript cannot compile TF2Autobot by removing the package-lock.json from the .dockerignore so it is included in the build process.