### PR TITLE
Add an option for denying trades with items on both sides of the trade.

### DIFF
--- a/src/classes/DiscordWebhook/sendTradeDeclined.ts
+++ b/src/classes/DiscordWebhook/sendTradeDeclined.ts
@@ -71,7 +71,7 @@ export default async function sendTradeDeclined(
     const declinedDescription = declined.reasonDescription;
     const declinedTradeSummary: Webhook = {
         username: optDW.displayName || botInfo.name,
-        avatar_url: optDW.avatarURL || optDW.avatarURL,
+        avatar_url: optDW.avatarURL || botInfo.avatarURL,
         content: '',
         embeds: [
             {

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -761,6 +761,20 @@ export default class MyHandler extends Handler {
             };
         }
 
+        // Check if the offer has items on both sides
+        if (
+            !opt.miscSettings.itemsOnBothSides.enable &&
+            exchange['our'].contains.items &&
+            exchange['their'].contains.items
+        ) {
+            offer.log('info', 'offer has items on both sides');
+            return {
+                action: 'decline',
+                reason: 'CONTAINS_ITEMS_ON_BOTH_SIDES',
+                meta: isContainsHighValue ? { highValue: highValueMeta } : undefined
+            };
+        }
+
         const itemsToGiveCount = offer.itemsToGive.length;
         const itemsToReceiveCount = offer.itemsToReceive.length;
 

--- a/src/classes/MyHandler/offer/notify/declined.ts
+++ b/src/classes/MyHandler/offer/notify/declined.ts
@@ -217,6 +217,9 @@ export default function declined(offer: TradeOffer, bot: Bot): void {
         reply = custom
             ? custom
             : declined + ' because the offer sent contains Mann Co. Supply Crate Key on both sides.';
+    } else if (offerReason.reason === 'CONTAINS_ITEMS_ON_BOTH_SIDES') {
+        const custom = opt.customMessage.decline.containsItemsOnBothSides;
+        reply = custom ? custom : declined + ' because the offer sent contains items on both sides.';
     } else {
         //
         const custom = opt.customMessage.decline.general;

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -40,7 +40,7 @@ export const DEFAULTS: JsonOptions = {
             withUncraft: true
         },
         itemsOnBothSides: {
-            enable: false
+            enable: true
         },
         checkUses: {
             duel: true,

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -39,6 +39,9 @@ export const DEFAULTS: JsonOptions = {
             enable: true,
             withUncraft: true
         },
+        itemsOnBothSides: {
+            enable: false
+        },
         checkUses: {
             duel: true,
             noiseMaker: true
@@ -631,7 +634,8 @@ export const DEFAULTS: JsonOptions = {
             failedToCounter: '',
             takingItemsWithIntentBuy: '',
             givingItemsWithIntentSell: '',
-            containsKeysOnBothSides: ''
+            containsKeysOnBothSides: '',
+            containsItemsOnBothSides: ''
         },
         accepted: {
             automatic: {
@@ -1213,6 +1217,7 @@ interface MiscSettings {
     sendGroupInvite?: OnlyEnable;
     skipItemsInTrade?: OnlyEnable;
     weaponsAsCurrency?: WeaponsAsCurrency;
+    itemsOnBothSides?: OnlyEnable;
     checkUses?: CheckUses;
     game?: Game;
     alwaysRemoveItemAttributes?: AlwaysRemoveItemAttributes;
@@ -1770,6 +1775,7 @@ interface DeclineNote {
     takingItemsWithIntentBuy?: string;
     givingItemsWithIntentSell?: string;
     containsKeysOnBothSides?: string;
+    containsItemsOnBothSides?: string;
 }
 
 interface AcceptedNote {

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -436,6 +436,16 @@ export const optionsSchema: jsonschema.Schema = {
                     required: ['enable', 'withUncraft'],
                     additionalProperties: false
                 },
+                itemsOnBothSides: {
+                    type: 'object',
+                    properties: {
+                        enable: {
+                            type: 'boolean'
+                        }
+                    },
+                    required: ['enable'],
+                    additionalProperties: false
+                },
                 checkUses: {
                     type: 'object',
                     properties: {
@@ -1869,6 +1879,9 @@ export const optionsSchema: jsonschema.Schema = {
                         },
                         containsKeysOnBothSides: {
                             type: 'string'
+                        },
+                        containsItemsOnBothSides: {
+                            type: 'string'
                         }
                     },
                     required: [
@@ -1889,7 +1902,8 @@ export const optionsSchema: jsonschema.Schema = {
                         'failedToCounter',
                         'takingItemsWithIntentBuy',
                         'givingItemsWithIntentSell',
-                        'containsKeysOnBothSides'
+                        'containsKeysOnBothSides',
+                        'containsItemsOnBothSides'
                     ],
                     additionalProperties: false
                 },


### PR DESCRIPTION
Adds an option for controlling whether or not a trade offer will be accepted / processed if both our and their side of a trade offer contain items other refined metal and keys.

Setting: miscSettings.itemsOnBothSides

Also fixes a typo in the sendTradeDeclined preventing the webhook from properly displaying the bot's avatar if not manually set in the options.

🫡