### PR TITLE
feat: Add ExpressLoad Inventory API integration

### DIFF
--- a/.example/options.json
+++ b/.example/options.json
@@ -446,6 +446,9 @@
         },
         "steamApis": {
             "enable": false
+        },
+        "expressLoad": {
+            "enable": false
         }
     },
     "discordChat": {

--- a/src/classes/InventoryApis/ExpressLoad.ts
+++ b/src/classes/InventoryApis/ExpressLoad.ts
@@ -1,0 +1,28 @@
+import { UnknownDictionaryKnownValues } from 'src/types/common';
+import Bot from '../Bot';
+import InventoryApi from './InventoryApi';
+
+export default class ExpressLoad extends InventoryApi {
+    constructor(bot: Bot) {
+        super(bot, 'expressLoad');
+    }
+
+    protected getURLAndParams(
+        steamID: string,
+        appID: number,
+        contextID: string
+    ): [string, UnknownDictionaryKnownValues] {
+        return [
+            `https://api.express-load.com/inventory/${steamID}/${appID}/${contextID}`,
+            {}
+        ];
+    }
+
+    protected getHeaders(): UnknownDictionaryKnownValues {
+        return {
+            'X-API-KEY': this.getApiKey(),
+            'User-Agent': 'TF2Autobot'
+        };
+    }
+
+}

--- a/src/classes/InventoryApis/InventoryApi.ts
+++ b/src/classes/InventoryApis/InventoryApi.ts
@@ -31,6 +31,11 @@ export default class InventoryApi {
         return ['', {}];
     }
 
+    // This method may be defined by a class extending InventoryAPI
+    protected getHeaders(): UnknownDictionaryKnownValues {
+        return {};
+    }
+
     // Adapted from node-steamcommunity
     public getUserInventoryContents(
         userID: SteamID | string,
@@ -58,6 +63,8 @@ export default class InventoryApi {
             return;
         }
 
+        const headers = this.getHeaders();
+
         let pos = 1;
         get([], []);
 
@@ -67,7 +74,8 @@ export default class InventoryApi {
                 params: {
                     ...apiCallParams,
                     start_assetid: start
-                }
+                },
+                headers: headers,
             }).then(
                 response => {
                     const result = response.data as GetUserInventoryContentsResult;

--- a/src/classes/InventoryGetter.ts
+++ b/src/classes/InventoryGetter.ts
@@ -2,6 +2,7 @@ import SteamID from 'steamid';
 import { EconItem } from '@tf2autobot/tradeoffer-manager';
 
 import Bot from './Bot';
+import ExpressLoad from "./InventoryApis/ExpressLoad";
 import InventoryApi from './InventoryApis/InventoryApi';
 import SteamSupply from './InventoryApis/SteamSupply';
 import SteamApis from './InventoryApis/SteamApis';
@@ -10,7 +11,7 @@ export default class InventoryGetter {
     private readonly inventoryApis: InventoryApi[];
 
     constructor(private readonly bot: Bot) {
-        this.inventoryApis = [new SteamSupply(this.bot), new SteamApis(this.bot)];
+        this.inventoryApis = [new SteamSupply(this.bot), new SteamApis(this.bot), new ExpressLoad(this.bot)];
     }
 
     getUserInventoryContents(

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -494,6 +494,9 @@ export const DEFAULTS: JsonOptions = {
         },
         steamApis: {
             enable: false
+        },
+        expressLoad: {
+            enable: false
         }
     },
 
@@ -1612,6 +1615,7 @@ interface ManualReview extends OnlyEnable {
 interface InventoryApis {
     steamSupply?: OnlyEnable;
     steamApis?: OnlyEnable;
+    expressLoad?: OnlyEnable;
 }
 
 // ------------ Discord Chat ---------------
@@ -2195,6 +2199,7 @@ export default interface Options extends JsonOptions {
     discordBotToken?: string;
     steamSupplyApiKey?: string;
     steamApisApiKey?: string;
+    expressLoadApiKey?: string;
 
     admins?: adminData[];
     keep?: string[];
@@ -2512,6 +2517,7 @@ export function loadOptions(options?: Options): Options {
         discordBotToken: getOption('discordBotToken', '', String, incomingOptions),
         steamSupplyApiKey: getOption('steamsupplyApiKey', '', String, incomingOptions),
         steamApisApiKey: getOption('steamapisApiKey', '', String, incomingOptions),
+        expressLoadApiKey: getOption('expressloadApiKey', '', String, incomingOptions),
 
         admins: getOption('admins', [], jsonParseAdminData, incomingOptions),
         keep: getOption('keep', [], jsonParseArray, incomingOptions),

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -1525,9 +1525,12 @@ export const optionsSchema: jsonschema.Schema = {
                 },
                 steamApis: {
                     $ref: '#/definitions/only-enable'
+                },
+                expressLoad: {
+                    $ref: '#/definitions/only-enable'
                 }
             },
-            required: ['steamSupply', 'steamApis'],
+            required: ['steamSupply', 'steamApis', 'expressLoad'],
             additionalProperties: false
         },
         discordChat: {

--- a/template.ecosystem.json
+++ b/template.ecosystem.json
@@ -28,6 +28,7 @@
                 "DISCORD_BOT_TOKEN": "",
                 "STEAMSUPPLY_API_KEY": "",
                 "STEAMAPIS_API_KEY": "",
+                "EXPRESSLOAD_API_KEY": "",
 
                 "ADMINS": [{ "steam": "<your steamid 64>", "discord": null }],
                 "KEEP": ["<steamid of person to keep in friendslist>"],

--- a/template.env
+++ b/template.env
@@ -15,6 +15,7 @@ MPTF_API_KEY=""
 DISCORD_BOT_TOKEN=""
 STEAMSUPPLY_API_KEY=""
 STEAMAPIS_API_KEY=""
+EXPRESSLOAD_API_KEY=""
 
 ADMINS=[{ "steam": "<your steamid 64>", "discord": null }]
 KEEP=["<steamid of person to keep in friendslist>"]


### PR DESCRIPTION
This pull request introduces a new inventory API integration called "ExpressLoad" and updates the configuration options to support it. The most important changes include adding the new `ExpressLoad` class, updating the `InventoryApi` base class to support custom headers, and modifying configuration files to include the new API.

### New Inventory API Integration:

* [`src/classes/InventoryApis/ExpressLoad.ts`](diffhunk://#diff-b4f268bade109626803d9fd557c3d4c85850bae19cd46ddfcac885ed58e706a2R1-R28): Added a new `ExpressLoad` class that extends `InventoryApi` and provides specific URL, parameters, and headers for the ExpressLoad API.
* [`src/classes/InventoryGetter.ts`](diffhunk://#diff-7c7e38f30d332c71f4754e1adb2941bbbac96a4e6757a6df82c34690c95c0bf5R5): Included the `ExpressLoad` class in the list of inventory APIs used by the `InventoryGetter` class. [[1]](diffhunk://#diff-7c7e38f30d332c71f4754e1adb2941bbbac96a4e6757a6df82c34690c95c0bf5R5) [[2]](diffhunk://#diff-7c7e38f30d332c71f4754e1adb2941bbbac96a4e6757a6df82c34690c95c0bf5L13-R14)

### Updates to Base Inventory API Class:

* [`src/classes/InventoryApis/InventoryApi.ts`](diffhunk://#diff-64a1dd91b6f19977777c78efc4577fa6eed2becd11ff7fb547563f9588fd1d10R34-R38): Added a `getHeaders` method to the `InventoryApi` class, which can be overridden by subclasses to provide custom headers. Modified the `getUserInventoryContents` method to include headers in the API requests. [[1]](diffhunk://#diff-64a1dd91b6f19977777c78efc4577fa6eed2becd11ff7fb547563f9588fd1d10R34-R38) [[2]](diffhunk://#diff-64a1dd91b6f19977777c78efc4577fa6eed2becd11ff7fb547563f9588fd1d10R66-R67) [[3]](diffhunk://#diff-64a1dd91b6f19977777c78efc4577fa6eed2becd11ff7fb547563f9588fd1d10L70-R78)

### Configuration Changes:

* `.example/options.json`, `src/classes/Options.ts`, `src/schemas/options-json/options.ts`, `template.ecosystem.json`, `template.env`: Updated configuration files to include options and API keys for the new `ExpressLoad` API. [[1]](diffhunk://#diff-040e38a9ef5c0317736ba785e4907a915efb53371e1780120bb036aa801257d9R449-R451) [[2]](diffhunk://#diff-b908d13062e3357d9eeab430cb13c1ee6398ebd24d3b6d8d2d93ee6a9ba56720R497-R499) [[3]](diffhunk://#diff-b908d13062e3357d9eeab430cb13c1ee6398ebd24d3b6d8d2d93ee6a9ba56720R1618) [[4]](diffhunk://#diff-b908d13062e3357d9eeab430cb13c1ee6398ebd24d3b6d8d2d93ee6a9ba56720R2202) [[5]](diffhunk://#diff-b908d13062e3357d9eeab430cb13c1ee6398ebd24d3b6d8d2d93ee6a9ba56720R2520) [[6]](diffhunk://#diff-1df7bfd667d9a43c86b3cc3c18ce2273e53a5811163d07484ed96135472b676bR1528-R1533) [[7]](diffhunk://#diff-9e9257e33da670ed0ff4fbebd28d42e3dfce63d1d101886c7c5d340238ada9d5R31) [[8]](diffhunk://#diff-2f184d2f5b2e5e60e0b7fbb01ac81495199bf042eed9fafc471f6bca4fb43946R18)