### PR TITLE
Fix Discord rate limit error loop

### DIFF
--- a/src/classes/DiscordBot.ts
+++ b/src/classes/DiscordBot.ts
@@ -63,7 +63,7 @@ export default class DiscordBot {
         } catch (err) {
             const error = err as DiscordAPIError;
 
-            if (error.code.toString() === 'TOKEN_INVALID') {
+            if (error.code && error.code.toString() === 'TOKEN_INVALID') {
                 log.error('Failed to login to Discord: bot token is invalid.');
                 throw error; // only "incorrect token" error should crash the bot, so "throw" is only here
             } else {


### PR DESCRIPTION
Solves [issue #1794](https://github.com/TF2Autobot/tf2autobot/issues/1794).

My instance threw this error on start:
```
[Timestamp] info: Signed in to Steam!
[Timestamp] info: Initializing Discord bot...
[Timestamp] debug: New web session
[Timestamp] warn: Failed to start Discord bot:  Cannot read properties of undefined (reading 'toString') {}
TypeError: Cannot read properties of undefined (reading 'toString')
    at DiscordBot.start (tf2autobot/dist/classes/DiscordBot.js:48:28)
    at async tf2autobot/dist/classes/Bot.js:633:29
[Timestamp] error: TF2Autobot failed to start properly, this is most likely a temporary error. See the log:
package.version: 5.13.2; node: v23.9.0 linux x64}
Stack trace:
TypeError: Cannot read properties of undefined (reading 'toString')
    at DiscordBot.start (tf2autobot/dist/classes/DiscordBot.js:48:28)
    at async tf2autobot/dist/classes/Bot.js:633:29
Bot has been up for 2 minutes.
[Timestamp] debug: Shutdown has been initialized, stopping... {"err":"Cannot read properties of undefined (reading 'toString')"}
```

Now it should log:
```sh
error: Failed to login to Discord, please use Steam chat for now. Error summary: Not enough sessions remaining to spawn 1 shards; only 0 remaining; resets at [Timestamp] {}
```