### PR TITLE
🔨 Change schema update interval from every 24 hours to 5 minutes

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -1260,7 +1260,7 @@ export default class Bot {
             () => {
                 this.setProperties();
             },
-            24 * 60 * 60 * 1000
+            5 * 60 * 1000 // Every 5 minutes
         );
     }
 


### PR DESCRIPTION
Prevent the bot from crashing on new update with new items due to outdated schema.