### PR TITLE
🔄️ Bump @tf2autobot/bptf-listings with changes from @Hexenum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "5.15.0",
             "license": "MIT",
             "dependencies": {
-                "@tf2autobot/bptf-listings": "^5.7.12",
+                "@tf2autobot/bptf-listings": "^5.8.0",
                 "@tf2autobot/bptf-login": "^2.4.1",
                 "@tf2autobot/filter-axios-error": "^1.5.6",
                 "@tf2autobot/jsonlint": "^1.0.0",
@@ -1738,9 +1738,9 @@
             "license": "MIT"
         },
         "node_modules/@tf2autobot/bptf-listings": {
-            "version": "5.7.12",
-            "resolved": "https://registry.npmjs.org/@tf2autobot/bptf-listings/-/bptf-listings-5.7.12.tgz",
-            "integrity": "sha512-cqj4j13Bxe4bVnmDFDY2XboHaeMvHhG1915pRxLkRanGhvpTagGkzYXKkF0u6USd8R4Pekc28hHTGLC/LFx15A==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@tf2autobot/bptf-listings/-/bptf-listings-5.8.0.tgz",
+            "integrity": "sha512-MQ2GWljMU8Q2OuHdoF6Z9B0VwpkvGK/QFttrnjy+3z78d8UDWrWvLKaEh34yd4Je43BtvpNm5VyMlZjh32B2YQ==",
             "license": "MIT",
             "dependencies": {
                 "@tf2autobot/filter-axios-error": "^1.5.6",
@@ -1749,6 +1749,7 @@
                 "async": "^3.2.6",
                 "axios": "^1.18.1",
                 "events": "^3.3.0",
+                "https-proxy-agent": "^7.0.6",
                 "steamid": "^2.1.0",
                 "util": "^0.12.5"
             }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "updateMessage": "Steam/TF2 is quite unstable right now, update/restart at your own will.",
     "homepage": "https://github.com/TF2Autobot/tf2autobot#readme",
     "dependencies": {
-        "@tf2autobot/bptf-listings": "^5.7.12",
+        "@tf2autobot/bptf-listings": "^5.8.0",
         "@tf2autobot/bptf-login": "^2.4.1",
         "@tf2autobot/filter-axios-error": "^1.5.6",
         "@tf2autobot/jsonlint": "^1.0.0",


### PR DESCRIPTION
https://github.com/TF2Autobot/node-bptf-listings/pull/13

Add proxy support, optimize API rate limits, and extend update queue timeout
  - Add HTTPS proxy support via https-proxy-agent with config.json
  - Optimize API utilization: 6s wait times for 100% throughput
  - Update queue timeout 30m - will drop items that are in queue for longer than 30minutes
  - Add comprehensive debug logging system with toggle

  Performance improvements:
  - postPatchWaitTime: 10s → 6s
  - deleteV2WaitTime: 10s → 6s

Credit: @Hexenum
<img width="877" height="626" alt="image" src="https://github.com/user-attachments/assets/32e605a1-e861-428f-b151-46c3db5948d8" />
