### PR TITLE
🔨 Bypass getTradeOfferURL if already cached/created

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -1188,7 +1188,16 @@ export default class Bot {
                                 callback(err);
                             });
                     },
-                    (callback): void => {
+                    async (callback): Promise<void> => {
+                        const tradeOfferUrl = await this.getTradeOfferUrl();
+
+                        if (tradeOfferUrl) {
+                            this.tradeOfferUrl = tradeOfferUrl;
+                            /* eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
+                            return callback(null);
+                        }
+
+                        // Steam can always throw 429 error on this one, especially after weekly Wednesday maintenance
                         this.community.getTradeURL((err, url) => {
                             if (err) {
                                 /* eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
@@ -1196,6 +1205,7 @@ export default class Bot {
                             }
 
                             this.tradeOfferUrl = url;
+                            this.cacheTradeOfferUrl(tradeOfferUrl);
                             /* eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
                             return callback(null);
                         });
@@ -1521,6 +1531,25 @@ export default class Bot {
 
         await files.writeFile(tokenPath, '', false).catch(() => {
             // Ignore error
+        });
+    }
+
+    private async getTradeOfferUrl(): Promise<string | null> {
+        const tradeOfferUrlPath = this.handler.getPaths.files.tradeOfferUrl;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const tradeOfferUrl = (await files.readFile(tradeOfferUrlPath, false).catch(err => null)) as string;
+
+        if (!tradeOfferUrl) {
+            return null;
+        }
+        return tradeOfferUrl;
+    }
+
+    private cacheTradeOfferUrl(tradeOfferUrl: string): void {
+        const tradeOfferUrlPath = this.handler.getPaths.files.tradeOfferUrl;
+
+        files.writeFile(tradeOfferUrlPath, tradeOfferUrl, false).catch(() => {
+            log.error('Error saving Trade Offer Url.');
         });
     }
 

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -2462,7 +2462,6 @@ function replaceOldProperties(options: DeprecatedJsonOptions): boolean {
 
     //@ts-ignore
     if (options.bypass?.bannedPeople !== undefined) {
-
         //@ts-ignore
         const mptfCheckValue = options.bypass.bannedPeople?.checkMptfBanned;
 
@@ -2474,7 +2473,6 @@ function replaceOldProperties(options: DeprecatedJsonOptions): boolean {
                 checkMptfBanned: process.env.MPTF_API_KEY !== undefined ? mptfCheckValue : false // below v4.13.0 -> v4.13.1
             };
         }
-
 
         //@ts-ignore
         delete options.bypass.bannedPeople;

--- a/src/resources/paths.ts
+++ b/src/resources/paths.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 
 interface FilePaths {
     refreshToken: string;
+    tradeOfferUrl: string;
     pollData: string;
     loginAttempts: string;
     pricelist: string;
@@ -36,6 +37,7 @@ export default function genPaths(steamAccountName: string, maxPollDataSizeMB = 5
     return {
         files: {
             refreshToken: path.join(__dirname, `../../files/${steamAccountName}/refreshToken.txt`),
+            tradeOfferUrl: path.join(__dirname, `../../files/${steamAccountName}/tradeOfferUrl.txt`),
             pollData: pollDataPath,
             loginAttempts: path.join(__dirname, `../../files/${steamAccountName}/loginattempts.json`),
             pricelist: path.join(__dirname, `../../files/${steamAccountName}/pricelist.json`),


### PR DESCRIPTION
Prevent Steam 429 error during starting the bot.

Create a file named `tradeOfferUrl.txt` inside the `.../tf2autobot/files/<botSteamUsername>` directory/folder, then copy and paste your bot's Steam Trade Offer URL, and then start the bot.

<img width="608" height="679" alt="image" src="https://github.com/user-attachments/assets/700f4221-490a-4e2c-a55c-94ca0f356190" />
