### PR TITLE
🔄️ Handle trade offer URL 429 during startup

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -46,6 +46,12 @@ import filterAxiosError from '@tf2autobot/filter-axios-error';
 import { axiosAbortSignal } from '../lib/helpers';
 import { apiRequest } from '../lib/apiRequest';
 
+type Callback = (err?: Error | null) => void;
+type HttpError = Error & { code?: string | number };
+
+const TRADE_OFFER_URL_RETRY_BASE_DELAY = 5 * 1000;
+const TRADE_OFFER_URL_RETRY_MAX_DELAY = 5 * 60 * 1000;
+
 export interface SteamTokens {
     refreshToken: string;
     accessToken: string;
@@ -153,6 +159,8 @@ export default class Bot {
     public userID?: string;
 
     private halted = false;
+
+    private tradeOfferUrlRetryTimeout: NodeJS.Timeout = null;
 
     public autoRefreshListingsInterval: NodeJS.Timeout;
 
@@ -1188,27 +1196,10 @@ export default class Bot {
                                 callback(err);
                             });
                     },
-                    async (callback): Promise<void> => {
-                        const tradeOfferUrl = await this.getTradeOfferUrl();
-
-                        if (tradeOfferUrl) {
-                            this.tradeOfferUrl = tradeOfferUrl;
-                            /* eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
-                            return callback(null);
-                        }
-
-                        // Steam can always throw 429 error on this one, especially after weekly Wednesday maintenance
-                        this.community.getTradeURL((err, url) => {
-                            if (err) {
-                                /* eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
-                                return callback(err);
-                            }
-
-                            this.tradeOfferUrl = url;
-                            this.cacheTradeOfferUrl(url);
-                            /* eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
-                            return callback(null);
-                        });
+                    (callback: Callback): void => {
+                        void this.setupTradeOfferUrl()
+                            .then(() => callback(null))
+                            .catch(err => callback(err as Error));
                     }
                 ],
                 (item, callback) => {
@@ -1534,15 +1525,77 @@ export default class Bot {
         });
     }
 
-    private async getTradeOfferUrl(): Promise<string | null> {
-        const tradeOfferUrlPath = this.handler.getPaths.files.tradeOfferUrl;
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const tradeOfferUrl = (await files.readFile(tradeOfferUrlPath, false).catch(err => null)) as string;
+    private async setupTradeOfferUrl(): Promise<void> {
+        const cachedTradeOfferUrl = await this.getCachedTradeOfferUrl();
 
-        if (!tradeOfferUrl) {
+        if (cachedTradeOfferUrl !== null) {
+            this.tradeOfferUrl = cachedTradeOfferUrl;
+            return;
+        }
+
+        try {
+            await this.refreshTradeOfferUrl();
+        } catch (err) {
+            if (!this.isSteamHttp429(err as Error)) {
+                throw err;
+            }
+
+            log.warn('Steam returned HTTP 429 while getting trade offer URL; continuing startup and retrying: ', err);
+            this.scheduleTradeOfferUrlRetry();
+        }
+    }
+
+    private refreshTradeOfferUrl(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.community.getTradeURL((err, url) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+
+                if (!url) {
+                    reject(new Error('Steam did not return a trade offer URL'));
+                    return;
+                }
+
+                this.tradeOfferUrl = url;
+                this.cacheTradeOfferUrl(url);
+                resolve();
+            });
+        });
+    }
+
+    private scheduleTradeOfferUrlRetry(attempt = 1): void {
+        if (this.tradeOfferUrlRetryTimeout) {
+            return;
+        }
+
+        const delay = Math.min(attempt * TRADE_OFFER_URL_RETRY_BASE_DELAY, TRADE_OFFER_URL_RETRY_MAX_DELAY);
+
+        this.tradeOfferUrlRetryTimeout = setTimeout(() => {
+            this.tradeOfferUrlRetryTimeout = null;
+
+            void this.refreshTradeOfferUrl().catch((err: Error) => {
+                log.warn('Failed to refresh trade offer URL, retrying later: ', err);
+                this.scheduleTradeOfferUrlRetry(attempt + 1);
+            });
+        }, delay);
+    }
+
+    private isSteamHttp429(err: Error): boolean {
+        const httpError = err as HttpError;
+        return httpError.code === 429 || httpError.code === '429' || httpError.message === 'HTTP error 429';
+    }
+
+    private async getCachedTradeOfferUrl(): Promise<string | null> {
+        const tradeOfferUrlPath = this.handler.getPaths.files.tradeOfferUrl;
+        const tradeOfferUrl = (await files.readFile(tradeOfferUrlPath, false).catch(() => null)) as unknown;
+
+        if (typeof tradeOfferUrl !== 'string' || tradeOfferUrl.trim() === '') {
             return null;
         }
-        return tradeOfferUrl;
+
+        return tradeOfferUrl.trim();
     }
 
     private cacheTradeOfferUrl(tradeOfferUrl: string): void {


### PR DESCRIPTION
Cherry-pick from @Hexenum's fork.

Let the bot to keep on trying to get the `tradeOfferUrl` without crashing the bot for up to 5 minutes. Once obtained, cache it into the `../tf2autobot/files/<botSteamUsername>/tradeOfferUrl.txt`


If it's still crashing, then do the workaround to manually bypass getting the `tradeOfferUrl`:

<img width="610" height="271" alt="image" src="https://github.com/user-attachments/assets/ebd2649b-c591-439a-85d9-8a6c6a10a811" />

