### PR TITLE
🔨 Fix schema not updating every 5 minutes

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -125,8 +125,6 @@ export default class Bot {
         spy: string[];
     };
 
-    public updateSchemaPropertiesInterval: NodeJS.Timeout;
-
     // Settings
     private readonly maxLoginAttemptsWithinPeriod: number = 3;
 
@@ -899,6 +897,8 @@ export default class Bot {
         this.addListener(this.tf2, 'displayNotification', this.handler.onDisplayNotification.bind(this.handler), true);
         this.addListener(this.tf2, 'itemBroadcast', this.handler.onItemBroadcast.bind(this.handler), true);
 
+        this.addListener(this.schemaManager, 'schema', this.setProperties.bind(this), false);
+
         return new Promise((resolve, reject) => {
             async.eachSeries(
                 [
@@ -1264,18 +1264,6 @@ export default class Bot {
             sniper: this.schema.getWeaponsForCraftingByClass('Sniper'),
             spy: this.schema.getWeaponsForCraftingByClass('Spy')
         };
-
-        clearInterval(this.updateSchemaPropertiesInterval);
-        this.refreshSchemaProperties();
-    }
-
-    private refreshSchemaProperties(): void {
-        this.updateSchemaPropertiesInterval = setInterval(
-            () => {
-                this.setProperties();
-            },
-            5 * 60 * 1000 // Every 5 minutes
-        );
     }
 
     setCookies(cookies: string[]): Promise<void> {

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -1026,7 +1026,7 @@ export default class Bot {
                     },
                     (callback): void => {
                         this.schemaManager = new SchemaManager({
-                            updateTime: 1 * 60 * 60 * 1000,
+                            updateTime: 5 * 60 * 1000, // Every 5 minutes
                             lite: true
                         });
 

--- a/src/classes/BotManager.ts
+++ b/src/classes/BotManager.ts
@@ -204,7 +204,6 @@ export default class BotManager {
             // Stop updating schema
             clearTimeout(this.schemaManager?._updateTimeout);
             clearInterval(this.schemaManager?._updateInterval);
-            clearInterval(this.bot.updateSchemaPropertiesInterval);
 
             // Stop heartbeat and inventory timers
             clearInterval(this.bot.listingManager?._heartbeatInterval);


### PR DESCRIPTION
Correction for the #1925 (released [v5.16.0](https://github.com/TF2Autobot/tf2autobot/releases/tag/v5.16.0)).
This will also wait for `schema` event before updating the schema properties (not set time interval).

Fixed undefined schemaManager on this pull request: [57ac8c1](https://github.com/TF2Autobot/tf2autobot/pull/1954/commits/57ac8c19ae1bcae03c2d80c6b89a87f30bb79216)