### PR TITLE
🔨 Add allowScripts in package.json for npm v12 or later

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,5 +105,9 @@
     "private": true,
     "_moduleAliases": {
         "@pricer": "dist/lib/pricer"
+    },
+    "allowScripts": {
+        "protobufjs@7.6.5": true,
+        "protobufjs@6.11.6": true
     }
 }


### PR DESCRIPTION
Without this, we will get:
<img width="643" height="562" alt="image" src="https://github.com/user-attachments/assets/b2a4eaba-5c67-4651-b14f-177fbe0ff655" />

And might cause the bot to fail/crash when it needs to use dependency that use protobufjs.

I might actually just upgrade protobufjs@7.6.5 in [TF2Autobot/tf2](https://github.com/TF2Autobot/node-tf2) to the latest v8, but then I will also need to fork [node-steam-user](https://github.com/DoctorMcKay/node-steam-user) (protobufjs@7.2.4), [node-steam-session](https://github.com/DoctorMcKay/node-steam-session) (protobufjs@7.1.0), and [node-steam-appticket](https://github.com/DoctorMcKay/node-steam-appticket) (protobufjs@6.8.8) and upgrade them all to the latest version.

Also [node-tf2-backpack](https://github.com/ZeusJunior/node-tf2-backpack) 💆‍♂️