### PR TITLE
🔨 Replace deprecated url.parse() with native URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
                 "steam-totp": "^2.1.2",
                 "steam-user": "^5.3.0",
                 "steamid": "^2.1.0",
-                "url": "^0.11.4",
                 "valid-url": "^1.0.9",
                 "winston": "^3.19.0",
                 "winston-daily-rotate-file": "^5.0.0",
@@ -9028,23 +9027,6 @@
             "dependencies": {
                 "punycode": "^2.1.0"
             }
-        },
-        "node_modules/url": {
-            "version": "0.11.4",
-            "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
-            "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
-            "dependencies": {
-                "punycode": "^1.4.1",
-                "qs": "^6.12.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/url/node_modules/punycode": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
         },
         "node_modules/util": {
             "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
         "steam-totp": "^2.1.2",
         "steam-user": "^5.3.0",
         "steamid": "^2.1.0",
-        "url": "^0.11.4",
         "valid-url": "^1.0.9",
         "winston": "^3.19.0",
         "winston-daily-rotate-file": "^5.0.0",

--- a/src/lib/extend/item/getSKU.ts
+++ b/src/lib/extend/item/getSKU.ts
@@ -120,7 +120,8 @@ function getDefindex(item: EconItem): number | null {
 
     const link = item.getAction('Item Wiki Page...');
     if (link !== null) {
-        return parseInt(new URL(link).searchParams.get('id').toString(), 10);
+        const id = new URL(link).searchParams.get('id');
+        return id ? parseInt(id.toString(), 10) : null;
     }
 
     // Last option is to get the name of the item and try and get the defindex that way

--- a/src/lib/extend/item/getSKU.ts
+++ b/src/lib/extend/item/getSKU.ts
@@ -2,7 +2,6 @@
 import { EconItem } from '@tf2autobot/tradeoffer-manager';
 import SchemaManager, { Item, Paints, Schema } from '@tf2autobot/tf2-schema';
 import SKU from '@tf2autobot/tf2-sku';
-import url from 'url';
 import { fixItem } from '../../items';
 
 interface ParsedDescriptions {
@@ -121,7 +120,7 @@ function getDefindex(item: EconItem): number | null {
 
     const link = item.getAction('Item Wiki Page...');
     if (link !== null) {
-        return parseInt(url.parse(link, true).query.id.toString(), 10);
+        return parseInt(new URL(link).searchParams.get('id').toString(), 10);
     }
 
     // Last option is to get the name of the item and try and get the defindex that way


### PR DESCRIPTION
<img width="643" height="98" alt="image" src="https://github.com/user-attachments/assets/2058900e-a017-482e-a8c2-a9d2671f0392" />
