### PR TITLE
🚮 Remove steamrep entirely, align with rep.autobot.tf

### DIFF
--- a/src/lib/bans.ts
+++ b/src/lib/bans.ts
@@ -16,10 +16,6 @@ interface SiteResult {
     content?: string;
 }
 
-interface SiteResultBptf extends SiteResult {
-    isSteamRepBanned: boolean;
-}
-
 interface BansEntry {
     bot: Bot;
     userID?: string;
@@ -30,17 +26,15 @@ interface BansEntry {
 export interface ResultSources {
     bptf?: SiteResult;
     mptf?: SiteResult;
-    steamrep?: SiteResult;
     untrusted?: SiteResult;
 }
 
-type Sites = 'TF2Autobot' | 'Marketplace.tf' | 'Backpack.tf' | 'Steamrep.com';
+type Sites = 'TF2Autobot' | 'Marketplace.tf' | 'Backpack.tf';
 
 interface RepAutobotTfContents {
     TF2Autobot: SiteResult | 'Error';
     'Marketplace.tf': SiteResult | 'Error';
     'Backpack.tf': SiteResult | 'Error';
-    'Steamrep.com': SiteResult | 'Error';
 }
 
 interface RepAutobotTf {
@@ -54,10 +48,6 @@ interface RepAutobotTf {
 
 export default class Bans {
     private _isBptfBanned: boolean = null;
-
-    private _isBptfSteamRepBanned: boolean = null;
-
-    private _isSteamRepBanned: boolean = null;
 
     private _isCommunityBanned: boolean = null;
 
@@ -109,8 +99,8 @@ export default class Bans {
                 }
             };
             const finalize = (results: ResultSources): IsBanned => {
-                const { bptf, mptf, steamrep, untrusted } = results;
-                const validResults = [bptf, mptf, steamrep, untrusted].filter(r => !!r);
+                const { bptf, mptf, untrusted } = results;
+                const validResults = [bptf, mptf, untrusted].filter(r => !!r);
                 const haveResults = validResults.length > 0;
                 if (haveResults) {
                     result = {
@@ -135,35 +125,21 @@ export default class Bans {
                             ? `banned${untrusted.content !== '' ? ` - ${untrusted.content}` : ''}`
                             : 'clean';
                     }
-
-                    if (steamrep) {
-                        result.contents['Steamrep.com:'] = steamrep.isBanned
-                            ? `banned${steamrep.content !== '' ? ` - ${steamrep.content}` : ''}`
-                            : 'clean';
-                    }
                 }
                 this.logIsBanned(result);
                 return result;
             };
 
-            // Else if rep.tf is not as primary, check from each website first
-            return await Promise.all([
-                this.isListedUntrusted(),
-                this.isMptfBanned(),
-                this.isSteamRepMarked(),
-                this.isBptfBanned()
-            ])
-                .then(([untrusted, mptf, steamrep, bptf]) => {
+            return await Promise.all([this.isListedUntrusted(), this.isMptfBanned(), this.isBptfBanned()])
+                .then(([untrusted, mptf, bptf]) => {
                     // If all success, proceed
-                    return finalize({ bptf, mptf, steamrep, untrusted });
+                    return finalize({ bptf, mptf, untrusted });
                 })
                 .catch(err => {
                     // Else if an error occurred, check if all cache say you are okay
                     if (
                         ![
                             this._isBptfBanned,
-                            this._isBptfSteamRepBanned,
-                            this._isSteamRepBanned,
                             this._isCommunityBanned,
                             this.repOpt.checkMptfBanned && this._isMptfBanned
                         ].some(b => b)
@@ -220,8 +196,6 @@ export default class Bans {
             })
                 .then(result => {
                     this._isBptfBanned = result.isBanned;
-                    this._isBptfSteamRepBanned = result.isSteamRepBanned;
-
                     return resolve({ isBanned: this._isBptfBanned, content: result.content });
                 })
                 .catch(err => {
@@ -229,16 +203,6 @@ export default class Bans {
                     log.debug(err);
                     return resolve(undefined);
                 });
-        });
-    }
-
-    private isSteamRepMarked(): Promise<SiteResult | undefined> {
-        // SteamRep no longer exists so we fallback to bptf steamrep data if it still holds it?
-        return new Promise(resolve => {
-            if (this._isBptfSteamRepBanned !== null) {
-                return resolve({ isBanned: this._isBptfSteamRepBanned });
-            }
-            return resolve(undefined);
         });
     }
 
@@ -334,7 +298,7 @@ export function isBptfBanned({
     bptfApiKey: string;
     userID: string;
     showLog?: boolean;
-}): Promise<SiteResultBptf> {
+}): Promise<SiteResult> {
     return new Promise((resolve, reject) => {
         apiRequest<BPTFGetUserInfo>({
             method: 'GET',
@@ -352,10 +316,9 @@ export function isBptfBanned({
                 const user = body.users[steamID];
                 const isBptfBanned =
                     user.bans && (user.bans.all !== undefined || user.bans['all features'] !== undefined);
-                const isSteamRepBanned = user.bans ? user.bans.steamrep_scammer === 1 : false;
                 const banReason = user.bans ? (user.bans.all?.reason ?? user.bans['all features']?.reason ?? '') : '';
 
-                return resolve({ isBanned: isBptfBanned, content: banReason, isSteamRepBanned });
+                return resolve({ isBanned: isBptfBanned, content: banReason });
             })
             .catch(err => {
                 if (err) {


### PR DESCRIPTION
Steamrep.com has long gone. If backpack.tf still holds the data, it should already be marked as banned on backpack.tf.

https://github.com/TF2Autobot/rep.autobot.tf/commit/98d8af55eb04967c88bb127e3e14767577846a04