### PR TITLE
✨ Send summary of accepted trade offer with escrow/trade hold

### DIFF
--- a/src/classes/DiscordWebhook/sendTradeSummary.ts
+++ b/src/classes/DiscordWebhook/sendTradeSummary.ts
@@ -148,7 +148,7 @@ export default async function sendTradeSummary(
                 description:
                     summary +
                     `\n${cTTimeTaken} ${t.convertTime(
-                        isAcceptedWithEscrow ? null : timeTakenToComplete,
+                        timeTakenToComplete,
                         timeTakenToProcessOrConstruct,
                         timeTakenToCounterOffer,
                         isOfferSent,

--- a/src/classes/DiscordWebhook/sendTradeSummary.ts
+++ b/src/classes/DiscordWebhook/sendTradeSummary.ts
@@ -14,8 +14,8 @@ export default async function sendTradeSummary(
     bot: Bot,
     timeTakenToComplete: number,
     timeTakenToProcessOrConstruct: number,
-    timeTakenToCounterOffer: number | undefined,
-    isOfferSent: boolean | undefined,
+    timeTakenToCounterOffer: number,
+    isOfferSent: boolean,
     isAcceptedWithEscrow: boolean
 ): Promise<void> {
     const optBot = bot.options;

--- a/src/classes/DiscordWebhook/sendTradeSummary.ts
+++ b/src/classes/DiscordWebhook/sendTradeSummary.ts
@@ -15,7 +15,8 @@ export default async function sendTradeSummary(
     timeTakenToComplete: number,
     timeTakenToProcessOrConstruct: number,
     timeTakenToCounterOffer: number | undefined,
-    isOfferSent: boolean | undefined
+    isOfferSent: boolean | undefined,
+    isAcceptedWithEscrow: boolean
 ): Promise<void> {
     const optBot = bot.options;
     const optDW = optBot.discordWebhook;
@@ -44,7 +45,16 @@ export default async function sendTradeSummary(
 
     const keyPrices = bot.pricelist.getKeyPrices;
     const value = t.valueDiff(offer);
-    const summary = t.summarizeToChat(offer, bot, 'summary-accepted', true, value, false, isOfferSent);
+    const summary = t.summarizeToChat(
+        offer,
+        bot,
+        'summary-accepted',
+        true,
+        value,
+        false,
+        isOfferSent,
+        isAcceptedWithEscrow
+    );
 
     // Mention owner on the sku(s) specified in discordWebhook.tradeSummary.mentionOwner.itemSkus
     const enableMentionOnSpecificSKU = optDW.tradeSummary.mentionOwner.enable;
@@ -251,7 +261,8 @@ export default async function sendTradeSummary(
                 isOfferSent,
                 timeTakenToComplete,
                 timeTakenToProcessOrConstruct,
-                timeTakenToCounterOffer
+                timeTakenToCounterOffer,
+                isAcceptedWithEscrow
             );
         });
     });

--- a/src/classes/DiscordWebhook/sendTradeSummary.ts
+++ b/src/classes/DiscordWebhook/sendTradeSummary.ts
@@ -102,7 +102,10 @@ export default async function sendTradeSummary(
               } trade here!`
             : optDW.tradeSummary.mentionOwner.enable &&
                 optDW.ownerID.length > 0 &&
-                (isMentionOurItems || isMentionTheirItems || isMentionOnGreaterValue)
+                (isMentionOurItems ||
+                    isMentionTheirItems ||
+                    isMentionOnGreaterValue ||
+                    (optDW.tradeSummary.mentionOwner.withEscrow && isAcceptedWithEscrow))
               ? optDW.ownerID.map(id => `<@!${id}>`).join(', ')
               : '';
 

--- a/src/classes/DiscordWebhook/sendTradeSummary.ts
+++ b/src/classes/DiscordWebhook/sendTradeSummary.ts
@@ -148,7 +148,7 @@ export default async function sendTradeSummary(
                 description:
                     summary +
                     `\n${cTTimeTaken} ${t.convertTime(
-                        timeTakenToComplete,
+                        isAcceptedWithEscrow ? null : timeTakenToComplete,
                         timeTakenToProcessOrConstruct,
                         timeTakenToCounterOffer,
                         isOfferSent,

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -2264,7 +2264,7 @@ export default class MyHandler extends Handler {
 
                 const isAcceptedWithEscrow = offer.state === TradeOfferManager.ETradeOfferState['InEscrow'];
                 offer.data(`isAccepted${isAcceptedWithEscrow ? '_withEscrow' : ''}`, true);
-                offer.log('trade', `has been accepted${isAcceptedWithEscrow ? ' with trade hold.' : ''}.`);
+                offer.log('trade', `has been accepted${isAcceptedWithEscrow ? ' with trade hold' : ''}.`);
 
                 this.autokeys.check();
                 const result = processAccepted(offer, this.bot, timeTakenToComplete, isAcceptedWithEscrow);

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -2252,20 +2252,22 @@ export default class MyHandler extends Handler {
                 }
             }
 
-            if (offer.state === TradeOfferManager.ETradeOfferState['Accepted'] && !this.sentSummary[offer.id]) {
+            if (
+                (offer.state === TradeOfferManager.ETradeOfferState['Accepted'] ||
+                    offer.state === TradeOfferManager.ETradeOfferState['InEscrow']) &&
+                !this.sentSummary[offer.id]
+            ) {
                 // Only run this if the bot handled the offer and do not send again if already sent once
 
                 clearTimeout(this.resetSentSummaryTimeout);
                 this.sentSummary[offer.id] = true;
 
-                offer.data('isAccepted', true);
-                offer.log('trade', 'has been accepted.');
-
-                // Auto sell and buy keys if ref < minimum
+                const isAcceptedWithEscrow = offer.state === TradeOfferManager.ETradeOfferState['InEscrow'];
+                offer.data(`isAccepted${isAcceptedWithEscrow ? '_withEscrow' : ''}`, true);
+                offer.log('trade', `has been accepted${isAcceptedWithEscrow ? ' with trade hold.' : ''}.`);
 
                 this.autokeys.check();
-
-                const result = processAccepted(offer, this.bot, timeTakenToComplete);
+                const result = processAccepted(offer, this.bot, timeTakenToComplete, isAcceptedWithEscrow);
 
                 highValue.isDisableSKU = result.isDisableSKU;
                 highValue.theirItems = result.theirHighValuedItems;

--- a/src/classes/MyHandler/offer/accepted/processAccepted.ts
+++ b/src/classes/MyHandler/offer/accepted/processAccepted.ts
@@ -10,7 +10,8 @@ import { sendTradeSummary } from '../../../DiscordWebhook/export';
 export default function processAccepted(
     offer: i.TradeOffer,
     bot: Bot,
-    timeTakenToComplete: number
+    timeTakenToComplete: number,
+    isAcceptedWithEscrow: boolean
 ): { theirHighValuedItems: string[]; isDisableSKU: string[]; items: i.Items | undefined } {
     const opt = bot.options;
 
@@ -189,7 +190,8 @@ export default function processAccepted(
             timeTakenToComplete,
             timeTakenToProcessOrConstruct,
             timeTakenToCounterOffer,
-            isOfferSent
+            isOfferSent,
+            isAcceptedWithEscrow
         );
     } else {
         const itemsName = {
@@ -216,7 +218,8 @@ export default function processAccepted(
             isOfferSent,
             timeTakenToComplete,
             timeTakenToProcessOrConstruct,
-            timeTakenToCounterOffer
+            timeTakenToCounterOffer,
+            isAcceptedWithEscrow
         );
     }
 
@@ -236,7 +239,8 @@ export async function sendToAdmin(
     isOfferSent: boolean,
     timeTakenToComplete: number,
     timeTakenToProcessOrConstruct: number,
-    timeTakenToCounterOffer: number | undefined
+    timeTakenToCounterOffer: number | undefined,
+    isAcceptedWithEscrow: boolean
 ): Promise<void> {
     const opt = bot.options;
     const slots = bot.tf2.backpackSlots;
@@ -260,7 +264,7 @@ export async function sendToAdmin(
     } with ${offer.partner.getSteamID64()} is accepted. ✅`;
 
     const message2 =
-        t.summarizeToChat(offer, bot, 'summary-accepted', false, value, true, isOfferSent) +
+        t.summarizeToChat(offer, bot, 'summary-accepted', false, value, true, isOfferSent, isAcceptedWithEscrow) +
         (isShowOfferMessage
             ? (cTOfferMessage && offer.message ? `\n\n${cTOfferMessage}` : '\n\n💬 Offer message:') +
               ` "${offer.message}"`

--- a/src/classes/MyHandler/offer/accepted/processAccepted.ts
+++ b/src/classes/MyHandler/offer/accepted/processAccepted.ts
@@ -187,7 +187,7 @@ export default function processAccepted(
             offer,
             accepted,
             bot,
-            timeTakenToComplete,
+            isAcceptedWithEscrow ? null : timeTakenToComplete,
             timeTakenToProcessOrConstruct,
             timeTakenToCounterOffer,
             isOfferSent,
@@ -216,7 +216,7 @@ export default function processAccepted(
             itemList,
             keyPrices,
             isOfferSent,
-            timeTakenToComplete,
+            isAcceptedWithEscrow ? null : timeTakenToComplete,
             timeTakenToProcessOrConstruct,
             timeTakenToCounterOffer,
             isAcceptedWithEscrow
@@ -288,7 +288,7 @@ export async function sendToAdmin(
             slots !== undefined ? `/${slots}` : ''
         }` +
         `\n${cTTimeTaken} ${t.convertTime(
-            timeTakenToComplete,
+            isAcceptedWithEscrow ? null : timeTakenToComplete,
             timeTakenToProcessOrConstruct,
             timeTakenToCounterOffer,
             isOfferSent,

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -549,7 +549,8 @@ export const DEFAULTS: JsonOptions = {
             mentionOwner: {
                 enable: false,
                 itemSkus: [],
-                tradeValueInRef: 0
+                tradeValueInRef: 0,
+                withEscrow: true
             }
         },
         declinedTrade: {
@@ -1710,6 +1711,7 @@ interface MiscTradeSummary extends OnlyNote {
 interface MentionOwner extends OnlyEnable {
     itemSkus?: string[];
     tradeValueInRef?: number;
+    withEscrow?: boolean;
 }
 
 interface OfferReviewDW extends OnlyEnable {

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -449,7 +449,7 @@ export default class Trades {
                 const value = t.valueDiff(offer);
 
                 if (opt.discordWebhook.sendAlert.enable && opt.discordWebhook.sendAlert.url.main !== '') {
-                    const summary = t.summarizeToChat(offer, this.bot, 'summary-accepting', true, value, false, false);
+                    const summary = t.summarizeToChat(offer, this.bot, 'summary-accepting', true, value, false);
                     sendAlert(
                         `failed-${action}` as FailedActions,
                         this.bot,
@@ -465,8 +465,7 @@ export default class Trades {
                         [offer.id]
                     );
                 } else {
-                    const summary = t.summarizeToChat(offer, this.bot, 'summary-accepting', false, value, true, false);
-
+                    const summary = t.summarizeToChat(offer, this.bot, 'summary-accepting', false, value, true);
                     this.bot.messageAdmins(
                         `Failed to ${action} on the offer #${offer.id}:` +
                             summary +
@@ -648,7 +647,6 @@ export default class Trades {
                                             'summary-accepting',
                                             true,
                                             value,
-                                            false,
                                             false
                                         );
                                         sendAlert(
@@ -669,10 +667,8 @@ export default class Trades {
                                             'summary-accepting',
                                             false,
                                             value,
-                                            true,
-                                            false
+                                            true
                                         );
-
                                         this.bot.messageAdmins(
                                             `Error while trying to accept mobile confirmation on offer #${offer.id}:` +
                                                 summary +
@@ -778,8 +774,12 @@ export default class Trades {
                         const amount =
                             Math.min(
                                 length,
-                                // eslint-disable-next-line prettier/prettier
-                                Math.max(Math[overpay ? 'ceil' : 'floor']((NonPureWorth * (increaseDifference ? -1 : 1)) / value), 0)
+                                Math.max(
+                                    Math[overpay ? 'ceil' : 'floor'](
+                                        (NonPureWorth * (increaseDifference ? -1 : 1)) / value
+                                    ),
+                                    0
+                                )
                             ) || 0;
 
                         NonPureWorth += amount * value * (increaseDifference ? 1 : -1);

--- a/src/lib/tools/summarizeOffer.ts
+++ b/src/lib/tools/summarizeOffer.ts
@@ -17,7 +17,8 @@ export function summarizeToChat(
     withLink: boolean,
     value: ValueDiff,
     isSteamChat: boolean,
-    isOfferSent: boolean | undefined = undefined
+    isOfferSent: boolean | undefined = undefined,
+    isAcceptedWithEscrow: boolean | undefined = undefined
 ): string {
     const generatedSummary = summarize(offer, bot, type, withLink);
 
@@ -65,7 +66,9 @@ export function summarizeToChat(
     const isCountered = offer.data('processCounterTime') !== undefined;
     const reply =
         `\n\n${cTSummary}${
-            isOfferSent !== undefined ? ` (${isOfferSent ? 'chat' : `offer${isCountered ? ' - countered' : ''}`})` : ''
+            isOfferSent !== undefined
+                ? ` (${isOfferSent ? 'chat' : `offer${isCountered ? ' - countered' : ''}`})${isAcceptedWithEscrow ? ' - Trade Hold' : ''}`
+                : ''
         }\n` +
         `${cTAsked} ${generatedSummary.asked}` +
         `\n${cTOffered} ${generatedSummary.offered}` +

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -1652,6 +1652,9 @@ export const optionsSchema: jsonschema.Schema = {
                                 tradeValueInRef: {
                                     type: 'number',
                                     minimum: 0
+                                },
+                                withEscrow: {
+                                    type: 'boolean'
                                 }
                             },
                             required: ['enable', 'itemSkus', 'tradeValueInRef'],


### PR DESCRIPTION
The bot currently only sends accepted trade offer summary after the escrow/trade hold period completes (x days later, should be written in the time taken `To complete: 15 days` for example).

This will send both, and also add an option to mention owner on Discord webhook for accepted offer with escrow/trade hold.