### PR TITLE
🔨 Use Escrow Web API as a backup

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -1227,6 +1227,7 @@ export default class Bot {
                     this.manager.pollInterval = 10 * 1000;
                     this.setReady = true;
                     this.handler.onReady();
+                    this.lastTimeCallingDoPoll = dayjs().toDate();
                     this.manager.doPoll();
                     this.startVersionChecker();
                     this.initResetCacheInterval();

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -165,6 +165,8 @@ export default class Bot {
 
     public autoRefreshListingsInterval: NodeJS.Timeout;
 
+    public lastTimeCallingDoPoll: Date;
+
     /**
      * Resets the reconnection state and clears any pending reconnection timeout
      */

--- a/src/classes/Carts/CartQueue.ts
+++ b/src/classes/Carts/CartQueue.ts
@@ -207,10 +207,6 @@ export default class CartQueue {
 
             this.bot.manager.pollInterval = 10 * 1000;
             const now = dayjs();
-            if (this.bot.lastTimeCallingDoPoll === undefined) {
-                this.bot.lastTimeCallingDoPoll = now.toDate();
-            }
-
             const timeDiffInMs = now.diff(this.bot.lastTimeCallingDoPoll);
             if (timeDiffInMs === 0 || timeDiffInMs >= 10000) {
                 // Make sure to call doPoll only if first time or last call is more than or equal to 10 seconds

--- a/src/classes/Carts/CartQueue.ts
+++ b/src/classes/Carts/CartQueue.ts
@@ -208,7 +208,7 @@ export default class CartQueue {
             this.bot.manager.pollInterval = 10 * 1000;
             const now = dayjs();
             const timeDiffInMs = now.diff(this.bot.lastTimeCallingDoPoll);
-            if (timeDiffInMs === 0 || timeDiffInMs >= 10000) {
+            if (timeDiffInMs >= 10000) {
                 // Make sure to call doPoll only if first time or last call is more than or equal to 10 seconds
                 this.bot.lastTimeCallingDoPoll = now.toDate();
                 this.bot.manager.doPoll();

--- a/src/classes/Carts/CartQueue.ts
+++ b/src/classes/Carts/CartQueue.ts
@@ -36,6 +36,7 @@ export default class CartQueue {
         log.debug(`Added cart to queue at position ${position}`);
 
         this.carts.push(cart);
+        this.bot.manager.pollInterval = -1; // Temporarily disable trade offer polling
 
         setImmediate(() => {
             // Using set immediate so that the queue will first be handled when done with this event loop cycle
@@ -203,6 +204,20 @@ export default class CartQueue {
 
         if (this.busy || this.carts.length === 0) {
             log.debug('Already handling queue or queue is empty');
+
+            this.bot.manager.pollInterval = 10 * 1000;
+            const now = dayjs();
+            if (this.bot.lastTimeCallingDoPoll === undefined) {
+                this.bot.lastTimeCallingDoPoll = now.toDate();
+            }
+
+            const timeDiffInMs = now.diff(this.bot.lastTimeCallingDoPoll);
+            if (timeDiffInMs === 0 || timeDiffInMs >= 10000) {
+                // Make sure to call doPoll only if first time or last call is more than or equal to 10 seconds
+                this.bot.lastTimeCallingDoPoll = now.toDate();
+                this.bot.manager.doPoll();
+            }
+
             return;
         }
 

--- a/src/classes/Handler.ts
+++ b/src/classes/Handler.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import SteamID from 'steamid';
-import TradeOfferManager, { PollData, Meta, CustomError } from '@tf2autobot/tradeoffer-manager';
+import TradeOfferManager, { PollData, Meta, CustomError, ActionType } from '@tf2autobot/tradeoffer-manager';
 import Bot from './Bot';
 import { Entry, PricesDataObject, PricesObject } from './Pricelist';
 import { Blocked } from './MyHandler/interfaces';
@@ -67,7 +67,7 @@ export default abstract class Handler {
      * @param offer - The new trade offer
      */
     abstract onNewTradeOffer(offer: TradeOfferManager.TradeOffer): Promise<null | {
-        action: 'accept' | 'decline' | 'skip' | 'counter';
+        action: ActionType;
         reason: string;
         meta?: Meta;
     }>;
@@ -78,12 +78,7 @@ export default abstract class Handler {
      * @param action - The action
      * @param reason - The reason for the action
      */
-    abstract onOfferAction(
-        offer: TradeOfferManager.TradeOffer,
-        action: 'accept' | 'decline' | 'skip' | 'counter',
-        reason: string,
-        meta: Meta
-    ): void;
+    abstract onOfferAction(offer: TradeOfferManager.TradeOffer, action: ActionType, reason: string, meta: Meta): void;
 
     /**
      * Called when a new login attempt has been made

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -7,7 +7,8 @@ import TradeOfferManager, {
     Meta,
     WrongAboutOffer,
     Prices,
-    Items
+    Items,
+    ActionType
 } from '@tf2autobot/tradeoffer-manager';
 
 import pluralize from 'pluralize';
@@ -828,6 +829,18 @@ export default class MyHandler extends Handler {
 
             // Abort processing the offer.
             return;
+        }
+
+        // Check if there are any missing items in both sides
+        const isMissingItemsToGive = offer.itemsToGive.some(item => item.missing);
+        const isMissingItemsToReceive = offer.itemsToReceive.some(item => item.missing);
+
+        if (isMissingItemsToGive || isMissingItemsToReceive) {
+            // Ignore the trade, let polling offer automatically change offer state to 8 (InvalidItems)
+            return {
+                action: 'ignore',
+                reason: 'CONTAINS_MISSING_ITEMS'
+            };
         }
 
         const manualReviewEnabled = opt.manualReview.enable;
@@ -2334,12 +2347,7 @@ export default class MyHandler extends Handler {
         offer.data('meta', undefined);
     }
 
-    onOfferAction(
-        offer: TradeOffer,
-        action: 'accept' | 'decline' | 'skip' | 'counter',
-        reason: string,
-        meta: Meta
-    ): void {
+    onOfferAction(offer: TradeOffer, action: ActionType, reason: string, meta: Meta): void {
         if (offer.data('notify') !== true) {
             return;
         }
@@ -2816,7 +2824,7 @@ export default class MyHandler extends Handler {
 }
 
 interface OnNewTradeOffer {
-    action: 'accept' | 'decline' | 'skip' | 'counter';
+    action: ActionType;
     reason: string;
     meta?: Meta;
 }

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -351,7 +351,7 @@ export default class Trades {
                             this.bot.manager.pollInterval = 10 * 1000;
                             const now = dayjs();
                             const timeDiffInMs = now.diff(this.bot.lastTimeCallingDoPoll);
-                            if (timeDiffInMs === 0 || timeDiffInMs >= 10000) {
+                            if (timeDiffInMs >= 10000) {
                                 // Make sure to call doPoll only if first time or last call is more than or equal to 10 seconds
                                 this.bot.lastTimeCallingDoPoll = now.toDate();
                                 this.bot.manager.doPoll();

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -1542,7 +1542,7 @@ export default class Trades {
             const operation = retry.operation({
                 retries: 5,
                 factor: 2,
-                minTimeout: 1000,
+                minTimeout: 2000,
                 randomize: true
             });
 

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -1632,8 +1632,8 @@ export default class Trades {
     private async triggerRestartBot(steamID: string): Promise<void> {
         log.debug(`Escrow check problem occured, current failed count: ${this.escrowCheckFailedCount}`);
 
-        if (this.escrowCheckFailedCount >= 2) {
-            // if escrow check failed more than or equal to 2 times, then perform automatic restart (PM2 only)
+        if (this.escrowCheckFailedCount >= 5) {
+            // if escrow check failed more than or equal to 5 times, then perform automatic restart (PM2 only)
 
             const dwEnabled =
                 this.bot.options.discordWebhook.sendAlert.enable &&

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -144,6 +144,7 @@ export default class Trades {
         }
 
         offer.log('info', 'received offer');
+        this.bot.manager.pollInterval = -1; // Temporarily disable polling trade offers
         this.enqueueOffer(offer);
     }
 
@@ -344,6 +345,11 @@ export default class Trades {
 
                 void this.applyActionToOffer(response.action, response.reason, response.meta || {}, offer).finally(
                     () => {
+                        if (this.receivedOffers.length === 0) {
+                            // no more offers in queue, reset polling trade offers
+                            this.bot.manager.pollInterval = 10 * 1000;
+                            this.bot.manager.doPoll();
+                        }
                         this.finishProcessingOffer(offer.id);
                     }
                 );

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -52,7 +52,7 @@ type TradeOfferManagerWithApiCall = TradeOfferManager & {
 };
 
 const STEAM_RETRY_ATTEMPTS = 5;
-const STEAM_RETRY_BASE_DELAY = 5 * 1000;
+const STEAM_RETRY_BASE_DELAY_SECONDS = 5;
 
 export default class Trades {
     private itemsInTrade: string[] = [];
@@ -1616,8 +1616,8 @@ export default class Trades {
         return httpError.code === 429 || httpError.code === '429' || httpError.message === 'HTTP error 429';
     }
 
-    private getSteamRetryDelay(attempt: number): number {
-        return attempt * STEAM_RETRY_BASE_DELAY;
+    private getSteamRetryDelay(attempts: number): number {
+        return exponentialBackoff(attempts) * STEAM_RETRY_BASE_DELAY_SECONDS;
     }
 
     private retryToRestart(steamID: string): void {

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -350,10 +350,6 @@ export default class Trades {
 
                             this.bot.manager.pollInterval = 10 * 1000;
                             const now = dayjs();
-                            if (this.bot.lastTimeCallingDoPoll === undefined) {
-                                this.bot.lastTimeCallingDoPoll = now.toDate();
-                            }
-
                             const timeDiffInMs = now.diff(this.bot.lastTimeCallingDoPoll);
                             if (timeDiffInMs === 0 || timeDiffInMs >= 10000) {
                                 // Make sure to call doPoll only if first time or last call is more than or equal to 10 seconds

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -6,7 +6,8 @@ import TradeOfferManager, {
     Action,
     ItemsValue,
     ItemsDict,
-    Prices
+    Prices,
+    ActionType
 } from '@tf2autobot/tradeoffer-manager';
 import dayjs from 'dayjs';
 import pluralize from 'pluralize';
@@ -349,7 +350,7 @@ export default class Trades {
     }
 
     applyActionToOffer(
-        action: 'accept' | 'decline' | 'skip' | 'counter',
+        action: ActionType,
         reason: string,
         meta: Meta,
         offer: TradeOfferManager.TradeOffer
@@ -384,7 +385,7 @@ export default class Trades {
             }
         }
 
-        if (action === 'skip') {
+        if (action === 'skip' || action === 'ignore') {
             offer.itemsToGive.forEach(item => {
                 this.unsetItemInTrade = item.assetid;
             });
@@ -421,12 +422,7 @@ export default class Trades {
             });
     }
 
-    private onFailedAction(
-        offer: TradeOffer,
-        action: 'accept' | 'decline' | 'skip' | 'counter',
-        reason: string,
-        err: any
-    ): void {
+    private onFailedAction(offer: TradeOffer, action: ActionType, reason: string, err: any): void {
         log.warn(`Failed to ${action} on the offer #${offer.id}: `, err);
 
         /* Ignore notifying admin if eresult is "AlreadyRedeemed" or "InvalidState", or if the message includes that */

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -347,8 +347,19 @@ export default class Trades {
                     () => {
                         if (this.receivedOffers.length === 0) {
                             // no more offers in queue, reset polling trade offers
+
                             this.bot.manager.pollInterval = 10 * 1000;
-                            this.bot.manager.doPoll();
+                            const now = dayjs();
+                            if (this.bot.lastTimeCallingDoPoll === undefined) {
+                                this.bot.lastTimeCallingDoPoll = now.toDate();
+                            }
+
+                            const timeDiffInMs = now.diff(this.bot.lastTimeCallingDoPoll);
+                            if (timeDiffInMs === 0 || timeDiffInMs >= 10000) {
+                                // Make sure to call doPoll only if first time or last call is more than or equal to 10 seconds
+                                this.bot.lastTimeCallingDoPoll = now.toDate();
+                                this.bot.manager.doPoll();
+                            }
                         }
                         this.finishProcessingOffer(offer.id);
                     }

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -1423,9 +1423,16 @@ export default class Trades {
         log.debug('Checking escrow');
         clearTimeout(this.restartOnEscrowCheckFailed);
 
-        return this.checkEscrowWithWebApi(offer).catch((err: Error) => {
-            log.warn('Failed to check escrow with WebAPI, falling back to SteamCommunity HTML: ', err);
-            return this.checkEscrowWithHtml(offer);
+        if (!offer.id) {
+            // This will only get called if we send an offer with their Trade Offer URL
+            // Which for now only possible with !donate or !premium commands for tf2autobot
+            // I believe other forks has autodump feature, etc, which will use this.
+            return this.checkEscrowWithTradeHoldDurations(offer);
+        }
+
+        return this.checkEscrowWithHtml(offer).catch((err: Error) => {
+            log.warn('Failed to check escrow with SteamCommunity HTML, falling back to Web API: ', err);
+            return this.checkEscrowWithWebApi(offer);
         });
     }
 
@@ -1436,10 +1443,6 @@ export default class Trades {
             log.debug('Done checking escrow with offer WebAPI data');
             this.escrowCheckFailedCount = 0;
             return Promise.resolve(this.isEscrowEndDateActive(escrowEnds));
-        }
-
-        if (!offer.id) {
-            return this.checkEscrowWithTradeHoldDurations(offer);
         }
 
         return new Promise((resolve, reject) => {

--- a/src/types/modules/@tf2autobot/tradeoffer-manager/index.d.ts
+++ b/src/types/modules/@tf2autobot/tradeoffer-manager/index.d.ts
@@ -200,9 +200,11 @@ declare module '@tf2autobot/tradeoffer-manager' {
         }
 
         export interface Action {
-            action: 'accept' | 'decline' | 'skip' | 'counter';
+            action: ActionType;
             reason: string;
         }
+
+        export type ActionType = 'accept' | 'decline' | 'skip' | 'counter' | 'ignore';
 
         export interface Overstocked {
             reason: '🟦_OVERSTOCKED';


### PR DESCRIPTION
Flip implementation from https://github.com/TF2Autobot/tf2autobot/pull/1944

Some bots are accepting trade offer with escrow even when the `bypass.escrow.allow` is set to `false`, and it is possible that the Web API method returns invalid `escrow_end_date` (https://github.com/ValveSoftware/steam-for-linux/issues/7133).

Switching back to HTML with increased timeout, use of exponentialBackoff, and temporarily disable polling trade offers when receiving trade offers or handling carts queue should help increase the chance of success in getting the accurate user escrow data.