### PR TITLE
🔨 Add legacy sku generation as fallback when getting prices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@tf2autobot/steamcommunity": "^3.50.6",
                 "@tf2autobot/tf2": "^1.4.0",
                 "@tf2autobot/tf2-currencies": "^2.0.1",
-                "@tf2autobot/tf2-schema": "^4.9.0",
+                "@tf2autobot/tf2-schema": "^4.9.1",
                 "@tf2autobot/tf2-sku": "^3.1.0",
                 "@tf2autobot/tradeoffer-manager": "^2.20.8",
                 "async": "^3.2.6",
@@ -1676,12 +1676,12 @@
             }
         },
         "node_modules/@tf2autobot/tf2-schema": {
-            "version": "4.9.0",
-            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-4.9.0.tgz",
-            "integrity": "sha512-b21M2FBUjGxGVYPv/A/jbT5hYmFnuB0dJueriGTUbNFXcT+9XtP12fsPDkvPndDY54xg0jFMD6sH9mUoTQydsQ==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-schema/-/tf2-schema-4.9.1.tgz",
+            "integrity": "sha512-DKE3HesOAWS3UO+Xx4pfIfi8FUJe5saN38N7+4w42mEGiaoikeDf7jtiuXjCjDrnpBIIgzmsYTMmU37LOvRxZA==",
             "license": "MIT",
             "dependencies": {
-                "@tf2autobot/tf2-sku": "^3.0.0",
+                "@tf2autobot/tf2-sku": "^3.1.0",
                 "async": "^3.2.6",
                 "events": "^3.3.0",
                 "semver": "^7.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "5.17.1",
             "license": "MIT",
             "dependencies": {
-                "@tf2autobot/bptf-listings": "^5.9.2",
+                "@tf2autobot/bptf-listings": "^5.9.3",
                 "@tf2autobot/bptf-login": "^2.5.1",
                 "@tf2autobot/jsonlint": "^1.0.0",
                 "@tf2autobot/steamcommunity": "^3.50.6",
@@ -1512,13 +1512,13 @@
             "license": "MIT"
         },
         "node_modules/@tf2autobot/bptf-listings": {
-            "version": "5.9.2",
-            "resolved": "https://registry.npmjs.org/@tf2autobot/bptf-listings/-/bptf-listings-5.9.2.tgz",
-            "integrity": "sha512-mQq/oWJhOwKD2bzbaekV7arq/QDwx3knQP+UYC3n+CpiTq/W3F9PL7z8jHuulcLsAoYTe0knwIZdwYMKTXkrGA==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/@tf2autobot/bptf-listings/-/bptf-listings-5.9.3.tgz",
+            "integrity": "sha512-t+nlZoCO72jrqTmzJYXD6DeZnt1SDelD3iRzuqo7M3iq2JIIzRrT0d7H76H8CA1nEVJsK+CN3DztC1yesFNZIg==",
             "license": "MIT",
             "dependencies": {
                 "@tf2autobot/tf2-currencies": "^2.0.1",
-                "@tf2autobot/tf2-sku": "^3.0.0",
+                "@tf2autobot/tf2-sku": "^3.1.0",
                 "async": "^3.2.6",
                 "events": "^3.3.0",
                 "https-proxy-agent": "^7.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@tf2autobot/tf2": "^1.4.0",
                 "@tf2autobot/tf2-currencies": "^2.0.1",
                 "@tf2autobot/tf2-schema": "^4.9.0",
-                "@tf2autobot/tf2-sku": "^3.0.0",
+                "@tf2autobot/tf2-sku": "^3.1.0",
                 "@tf2autobot/tradeoffer-manager": "^2.20.8",
                 "async": "^3.2.6",
                 "bluebird": "^3.7.2",
@@ -1693,9 +1693,9 @@
             }
         },
         "node_modules/@tf2autobot/tf2-sku": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-sku/-/tf2-sku-3.0.0.tgz",
-            "integrity": "sha512-HghDgW9feMi98ttqVf0NtuKl97QWU/bjq/eiKBKTcju/rIR8D9iFDXIVTQyBI1LLkq2lCeOPeBlBwkt5xy4jxA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@tf2autobot/tf2-sku/-/tf2-sku-3.1.0.tgz",
+            "integrity": "sha512-jz9RdFKB3aY7pxnVF6HU3rkoFJ4WqUstczFVI/hfb3PluC8HDGXov4MyH+tIYXQ9uidD8T4Z46Cibtyam2QJqg==",
             "license": "MIT",
             "dependencies": {
                 "defaults": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@tf2autobot/tf2": "^1.4.0",
         "@tf2autobot/tf2-currencies": "^2.0.1",
         "@tf2autobot/tf2-schema": "^4.9.0",
-        "@tf2autobot/tf2-sku": "^3.0.0",
+        "@tf2autobot/tf2-sku": "^3.1.0",
         "@tf2autobot/tradeoffer-manager": "^2.20.8",
         "async": "^3.2.6",
         "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@tf2autobot/steamcommunity": "^3.50.6",
         "@tf2autobot/tf2": "^1.4.0",
         "@tf2autobot/tf2-currencies": "^2.0.1",
-        "@tf2autobot/tf2-schema": "^4.9.0",
+        "@tf2autobot/tf2-schema": "^4.9.1",
         "@tf2autobot/tf2-sku": "^3.1.0",
         "@tf2autobot/tradeoffer-manager": "^2.20.8",
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "updateMessage": "Resolves Steam HTTP 429 issue (but not if truly rate limited). If still persist please let us know.",
     "homepage": "https://github.com/TF2Autobot/tf2autobot#readme",
     "dependencies": {
-        "@tf2autobot/bptf-listings": "^5.9.2",
+        "@tf2autobot/bptf-listings": "^5.9.3",
         "@tf2autobot/bptf-login": "^2.5.1",
         "@tf2autobot/jsonlint": "^1.0.0",
         "@tf2autobot/steamcommunity": "^3.50.6",

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -10,6 +10,7 @@ import log from '../lib/logger';
 import validator from '../lib/validator';
 import { sendWebHookPriceUpdateV1, sendAlert, sendFailedPriceUpdate } from './DiscordWebhook/export';
 import IPricer, { GetItemPriceResponse, Item } from './IPricer';
+import * as timersPromises from 'timers/promises';
 
 export enum PricelistChangedSource {
     Command = 'COMMAND',
@@ -423,15 +424,24 @@ export default class Pricelist extends EventEmitter {
 
         if (entry.autoprice && !entry.isPartialPriced && !isBulk) {
             // skip this part if autoprice is false and/or isPartialPriced is true
-            const price: GetItemPriceResponse = await this.priceSource.getPrice(entry.sku).catch(err => {
-                throw new Error(
-                    `Unable to get current prices for ${entry.sku}: ${
-                        (err as ErrorRequest).body && (err as ErrorRequest).body.message
-                            ? (err as ErrorRequest).body.message
-                            : (err as ErrorRequest).message
-                    }`
-                );
-            });
+            let price: GetItemPriceResponse;
+            try {
+                price = await this.priceSource.getPrice(entry.sku);
+            } catch (err) {
+                log.warn('Failed to get item price, retrying with legacy sku generation...', err);
+                const legacySku = SKU.fromObject(SKU.fromString(entry.sku), true);
+
+                await timersPromises.setTimeout(1000);
+                price = await this.priceSource.getPrice(legacySku).catch(err_ => {
+                    throw new Error(
+                        `Unable to get current prices for ${entry.sku}: ${
+                            (err_ as ErrorRequest).body && (err_ as ErrorRequest).body.message
+                                ? (err_ as ErrorRequest).body.message
+                                : (err_ as ErrorRequest).message
+                        }`
+                    );
+                });
+            }
 
             const newPrices = {
                 buy: new Currencies(price.buy),
@@ -529,10 +539,18 @@ export default class Pricelist extends EventEmitter {
         try {
             return await this.priceSource.getPrice(sku).then(response => new ParsedPrice(response));
         } catch (err) {
-            const errStringify = JSON.stringify(err);
-            const errMessage = errStringify === '' ? (err as Error)?.message : errStringify;
-            log.debug(`getItemPrices failed ${errMessage}`);
-            return null;
+            // Try with legacy sku
+            log.warn('getItemPrices failed, retrying with legacy sku generation...', err);
+            const legacySku = SKU.fromObject(SKU.fromString(sku), true);
+            try {
+                await timersPromises.setTimeout(1000);
+                return await this.priceSource.getPrice(legacySku).then(response => new ParsedPrice(response));
+            } catch (err_) {
+                const errStringify = JSON.stringify(err_);
+                const errMessage = errStringify === '' ? (err_ as Error)?.message : errStringify;
+                log.warn(`getItemPrices failed ${errMessage}`);
+                return null;
+            }
         }
     }
 


### PR DESCRIPTION
Starting v3.0.0 of [@tf2autobot/tf2-sku](https://github.com/TF2Autobot/node-tf2-sku), the sku generation will be a bit different (refer [#1999](https://github.com/TF2Autobot/tf2autobot/pull/1999)), but the pricer might still use the legacy sku generation, which the bot will fail when getting price.
This will make the bot to retry getting prices with the legacy sku generation.

<img width="1406" height="948" alt="image" src="https://github.com/user-attachments/assets/c6d3e1ab-265e-48b0-8c27-e8cbd5df17df" />
