### PR TITLE
✅ Let tradeoffer-manager handle the polling

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -170,8 +170,6 @@ export default class Bot {
 
     public autoRefreshListingsInterval: NodeJS.Timeout;
 
-    public lastTimeCallingDoPoll: Date;
-
     /**
      * Resets the reconnection state and clears any pending reconnection timeout
      */
@@ -215,10 +213,10 @@ export default class Bot {
             useAccessToken: !this.options.steamApiKey, // https://github.com/DoctorMcKay/node-steam-tradeoffer-manager/wiki/Access-Tokens
             language: 'en',
             pollInterval: -1,
+            minimumPollInterval: 5 * 1000, // set minimum between doPoll() calls
             cancelTime: 15 * 60 * 1000,
             pendingCancelTime: 1.5 * 60 * 1000,
-            globalAssetCache: true,
-            assetCacheMaxItems: 50
+            globalAssetCache: false
         });
 
         this.bptf = new BptfLogin();
@@ -1232,7 +1230,6 @@ export default class Bot {
                     this.manager.pollInterval = 10 * 1000;
                     this.setReady = true;
                     this.handler.onReady();
-                    this.lastTimeCallingDoPoll = dayjs().toDate();
                     this.manager.doPoll();
                     this.startVersionChecker();
                     this.initResetCacheInterval();

--- a/src/classes/Carts/CartQueue.ts
+++ b/src/classes/Carts/CartQueue.ts
@@ -1,6 +1,5 @@
 import SteamID from 'steamid';
 import * as inspect from 'util';
-import dayjs from 'dayjs';
 import pluralize from 'pluralize';
 import Cart from './Cart';
 import Bot from '../Bot';
@@ -201,15 +200,7 @@ export default class CartQueue {
 
             log.debug('pollInterval re-enabled.');
             this.bot.manager.pollInterval = 10 * 1000;
-            const now = dayjs();
-            const timeDiffInMs = now.diff(this.bot.lastTimeCallingDoPoll);
-            if (timeDiffInMs >= 10000) {
-                // Make sure to call doPoll only if first time or last call is more than or equal to 10 seconds
-                this.bot.lastTimeCallingDoPoll = now.toDate();
-                log.debug('doPoll called.');
-                this.bot.manager.doPoll();
-            }
-
+            this.bot.manager.doPoll();
             return;
         }
 

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -514,14 +514,7 @@ export default class Trades {
 
             log.debug('pollInterval re-enabled.');
             this.bot.manager.pollInterval = 10 * 1000;
-            const now = dayjs();
-            const timeDiffInMs = now.diff(this.bot.lastTimeCallingDoPoll);
-            if (timeDiffInMs >= 10000) {
-                // Make sure to call doPoll only if first time or last call is more than or equal to 10 seconds
-                this.bot.lastTimeCallingDoPoll = now.toDate();
-                log.debug('doPoll called.');
-                this.bot.manager.doPoll();
-            }
+            this.bot.manager.doPoll();
             return;
         }
 


### PR DESCRIPTION
- Set `minimumPollInterval` to 5000 ms (default is 1000 ms) and remove `timeDiffInMs >= 10000` checks.
- Set `globalAssetCache` to `false` (unused)
- Set `assetCacheMaxItems` to default (not defined in constructor, 500).