### PR TITLE
✅ Add acknowledgeTradeProtection, fix stuck offers state

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -1204,7 +1204,7 @@ export default class Bot {
                             });
                     },
                     (callback: Callback): void => {
-                        void this.setupTradeOfferUrl()
+                        this.setupTradeOfferUrl()
                             .then(() => callback(null))
                             .catch(err => callback(err as Error));
                     }
@@ -1225,6 +1225,7 @@ export default class Bot {
                         return resolve();
                     }
 
+                    void this.checkTradeProtectionAcknowledged();
                     this.manager.pollInterval = 10 * 1000;
                     this.setReady = true;
                     this.handler.onReady();
@@ -1574,6 +1575,23 @@ export default class Bot {
         files.writeFile(tradeOfferUrlPath, tradeOfferUrl, false).catch(() => {
             log.error('Error saving Trade Offer Url.');
         });
+    }
+
+    // Reference: https://github.com/tf2-automatic/tf2-automatic/blob/9b98d2e5b6e3b0b9d0b82651debada7d2fd57b99/apps/bot/src/bot/bot.service.ts#L601
+    private async checkTradeProtectionAcknowledged(): Promise<void> {
+        const path = this.handler.getPaths.files.tradeProtectionAcknowledge;
+        const alreadyAcknowledge = (await files.readFile(path, true).catch(() => null)) as boolean;
+
+        if (!alreadyAcknowledge) {
+            // This should only be done once
+            this.community.acknowledgeTradeProtection(err => {
+                log.warn('Error on acknowledgeTradeProtection', err);
+            });
+
+            files.writeFile(path, true, true).catch(err => {
+                log.error('Error saving Trade Protection Acknowlege file', err);
+            });
+        }
     }
 
     sendMessage(steamID: SteamID | string, message: string): void {

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -1585,7 +1585,7 @@ export default class Bot {
         if (!alreadyAcknowledge) {
             // This should only be done once
             this.community.acknowledgeTradeProtection(err => {
-                log.warn('Error on acknowledgeTradeProtection', err);
+                if (err) log.warn('Error on acknowledgeTradeProtection', err);
             });
 
             files.writeFile(path, true, true).catch(err => {

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -1585,11 +1585,14 @@ export default class Bot {
         if (!alreadyAcknowledge) {
             // This should only be done once
             this.community.acknowledgeTradeProtection(err => {
-                if (err) log.warn('Error on acknowledgeTradeProtection', err);
-            });
+                if (err) {
+                    log.warn('Error on acknowledgeTradeProtection', err);
+                    return;
+                }
 
-            files.writeFile(path, true, true).catch(err => {
-                log.error('Error saving Trade Protection Acknowlege file', err);
+                files.writeFile(path, true, true).catch(err => {
+                    log.error('Error saving Trade Protection Acknowlege file', err);
+                });
             });
         }
     }

--- a/src/resources/paths.ts
+++ b/src/resources/paths.ts
@@ -8,6 +8,7 @@ interface FilePaths {
     loginAttempts: string;
     pricelist: string;
     blockedList: string;
+    tradeProtectionAcknowledge: string;
     dir: string;
 }
 
@@ -42,6 +43,7 @@ export default function genPaths(steamAccountName: string, maxPollDataSizeMB = 5
             loginAttempts: path.join(__dirname, `../../files/${steamAccountName}/loginattempts.json`),
             pricelist: path.join(__dirname, `../../files/${steamAccountName}/pricelist.json`),
             blockedList: path.join(__dirname, `../../files/${steamAccountName}/blockedList.json`),
+            tradeProtectionAcknowledge: path.join(__dirname, `../../files/${steamAccountName}/tpa.json`),
             dir: path.join(__dirname, `../../files/${steamAccountName}/`)
         },
         logs: {

--- a/src/types/modules/@tf2autobot/steamcommunity/index.d.ts
+++ b/src/types/modules/@tf2autobot/steamcommunity/index.d.ts
@@ -86,6 +86,8 @@ declare module '@tf2autobot/steamcommunity' {
         acceptConfirmationForObject(identitySecret: string, objectID: string, callback: (err?: Error) => void): void;
 
         getFriendsList(callback: (err?: Error, friendlist?: SteamCommunity.FriendList) => void): void;
+
+        acknowledgeTradeProtection(callback?: (err?: Error) => void): void;
     }
 
     namespace SteamCommunity {


### PR DESCRIPTION
I noticed my bot had "2 incoming offers" for 2 days, and when I check the /tradeoffers page, I can see "2 pending offers" while the Trade Protection Acknowledge popped up. When I click Acknowledge, the pending offers become 0 (because some items longer available/traded away), and it reflected on my bot logs. This behavior is also explained here: https://github.com/DoctorMcKay/node-steamcommunity/wiki/SteamCommunity#acknowledgetradeprotectioncallback

<img width="643" height="275" alt="image" src="https://github.com/user-attachments/assets/5509bc86-e3e8-43ea-ba71-4a034446f438" />


(Different bot, I forgot to take a screenshot of the above bot)
<img width="1009" height="839" alt="image" src="https://github.com/user-attachments/assets/6acf5173-7fa9-4732-9d23-bb48967f8243" />
