### PR TITLE
🚮 Remove sku standardize during startup

### DIFF
--- a/src/classes/Commands/sub-classes/PricelistManager.ts
+++ b/src/classes/Commands/sub-classes/PricelistManager.ts
@@ -181,8 +181,8 @@ export default class PricelistManagerCommands {
 
         let priceKey: string = undefined;
         if (params.id) {
-            priceKey = String(params.id);
             params.id = String(params.id);
+            priceKey = params.id;
             // force intent sell for assetid added
             params.intent = 1;
         }
@@ -383,8 +383,10 @@ export default class PricelistManagerCommands {
 
             let priceKey: string = undefined;
             if (params.id) {
-                priceKey = String(params.id);
                 params.id = String(params.id);
+                priceKey = params.id;
+                // force intent sell
+                params.intent = 1;
             }
             priceKey = priceKey ? priceKey : params.sku;
 

--- a/src/classes/Commands/sub-classes/PricelistManager.ts
+++ b/src/classes/Commands/sub-classes/PricelistManager.ts
@@ -267,13 +267,19 @@ export default class PricelistManagerCommands {
 
                     delete params.item;
                 } else {
-                    errorMessage.push(
-                        `❌ Failed to add "${itemToAdd}": Please only use "sku" or "item" parameter, ` +
-                            `OR check if you have missing something. Thank you.`
-                    );
-                    failed++;
-                    failedNotUsingItemOrSkuParam++;
-                    continue;
+                    const item = getItemFromParams(steamID, params, this.bot);
+
+                    if (item === null) {
+                        errorMessage.push(
+                            `❌ Failed to add "${itemToAdd}": Please only use "sku" or "item" parameter, ` +
+                                `OR check if you have missing something. Thank you.`
+                        );
+                        failed++;
+                        failedNotUsingItemOrSkuParam++;
+                        continue;
+                    }
+
+                    params.sku = SKU.fromObject(item);
                 }
             }
 
@@ -1036,8 +1042,15 @@ export default class PricelistManagerCommands {
 
         let priceKey: string = undefined;
         if (params.id) {
-            priceKey = String(params.id);
             params.id = String(params.id);
+            priceKey = params.id;
+
+            if (typeof params.intent === 'number' && [0, 2].includes(params.intent)) {
+                this.bot.sendMessage(
+                    steamID,
+                    `❌ Failed to update ${params.id}: Intent should only be sell for assetid!`
+                );
+            }
         }
         priceKey = priceKey ? priceKey : params.sku;
 
@@ -1242,20 +1255,32 @@ export default class PricelistManagerCommands {
 
                     delete params.item;
                 } else {
-                    errorMessage.push(
-                        `❌ Failed to update "${itemToUpdate}": Please only use "sku" or "item" parameter, ` +
-                            `OR check if you have missing something. Thank you.`
-                    );
-                    failed++;
-                    failedNotUsingItemOrSkuParam++;
-                    continue;
+                    const item = getItemFromParams(steamID, params, this.bot);
+
+                    if (item === null) {
+                        errorMessage.push(
+                            `❌ Failed to update "${itemToUpdate}": Please only use "sku" or "item" parameter, ` +
+                                `OR check if you have missing something. Thank you.`
+                        );
+                        failed++;
+                        failedNotUsingItemOrSkuParam++;
+                        continue;
+                    }
+
+                    params.sku = SKU.fromObject(item);
                 }
             }
 
             let priceKey: string = undefined;
             if (params.id) {
-                priceKey = String(params.id);
                 params.id = String(params.id);
+                priceKey = params.id;
+
+                if (typeof params.intent === 'number' && [0, 2].includes(params.intent)) {
+                    errorMessage.push(`❌ Failed to update ${params.id}: Intent should only be sell for assetid!`);
+                    failed++;
+                    continue;
+                }
             }
             priceKey = priceKey ? priceKey : sku;
 
@@ -1756,8 +1781,8 @@ export default class PricelistManagerCommands {
 
         let priceKey: string = undefined;
         if (params.id) {
-            priceKey = String(params.id);
             params.id = String(params.id);
+            priceKey = params.id;
         }
         priceKey = priceKey ? priceKey : sku;
 
@@ -2018,8 +2043,8 @@ export default class PricelistManagerCommands {
 
         let priceKey: string = undefined;
         if (params.id) {
-            priceKey = String(params.id);
             params.id = String(params.id);
+            priceKey = params.id;
         }
         priceKey = priceKey ? priceKey : sku;
         const match = this.bot.pricelist.getPrice({ priceKey });

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -800,10 +800,7 @@ export default class Pricelist extends EventEmitter {
                 continue;
             }
 
-            const standardizeSku = SKU.fromObject(SKU.fromString(sku));
-            prices[sku].sku = standardizeSku;
-            // This will cause two or more different entries created with different sku arrangements to be merged
-            this.prices[standardizeSku] = Entry.fromData(prices[sku], this.schema);
+            this.prices[sku] = Entry.fromData(prices[sku], this.schema);
         }
 
         errors = validator(this.prices, 'pricelist');


### PR DESCRIPTION
The sku standardization was added on v5.17.2 with the main goal is to standardize the sku in the pricelist ([#1999](https://github.com/TF2Autobot/tf2autobot/pull/1999)) and merge any duplicates, but I totally forgot about items added with `assetid` (or `id` parameter during the `!add` command).

- 🚮 Remove sku standardize during startup (517b54e)
- 🎨🔨 Cleanup and add some safeguard when adding/updating item with assetid (`!add id=`/`!update id=`).