### PR TITLE
✅ Add `offerMessages` and `unfriendMessage` in globalDisable

### DIFF
--- a/src/classes/Commands/sub-classes/Manager.ts
+++ b/src/classes/Commands/sub-classes/Manager.ts
@@ -472,19 +472,20 @@ export default class ManagerCommands {
         const removeFriends = async (total: number, friendsToRemove: string[], blockedFriends: string[]) => {
             for (const steamid of friendsToRemove) {
                 if (!blockedFriends.includes(steamid)) {
-                    const getFriend = this.bot.friends.getFriend(steamid);
-
-                    this.bot.sendMessage(
-                        steamid,
-                        this.bot.options.customMessage.clearFriends
-                            ? this.bot.options.customMessage.clearFriends.replace(
-                                  /%name%/g,
-                                  getFriend ? getFriend.player_name : steamid
-                              )
-                            : `/quote Hey ${
-                                  getFriend ? getFriend.player_name : steamid
-                              }! My owner has performed friend list clearance. Please feel free to add me again if you want to trade at a later time!`
-                    );
+                    if (!this.bot.options.globalDisable.unfriendMessage) {
+                        const getFriend = this.bot.friends.getFriend(steamid);
+                        this.bot.sendMessage(
+                            steamid,
+                            this.bot.options.customMessage.clearFriends
+                                ? this.bot.options.customMessage.clearFriends.replace(
+                                      /%name%/g,
+                                      getFriend ? getFriend.player_name : steamid
+                                  )
+                                : `/quote Hey ${
+                                      getFriend ? getFriend.player_name : steamid
+                                  }! My owner has performed friend list clearance. Please feel free to add me again if you want to trade at a later time!`
+                        );
+                    }
                 } else {
                     log.info(`Blocked user ${steamid} has been successfully unfriended!`);
                 }

--- a/src/classes/MyHandler/MyHandler.ts
+++ b/src/classes/MyHandler/MyHandler.ts
@@ -1938,7 +1938,7 @@ export default class MyHandler extends Handler {
                     )}`
                 );
 
-                if (opt.offerReceived.sendPreAcceptMessage.enable) {
+                if (!this.opt.globalDisable.offerMessages && opt.offerReceived.sendPreAcceptMessage.enable) {
                     const preAcceptMessage = opt.customMessage.accepted.automatic;
 
                     MyHandler.sendPreAcceptedMessage(
@@ -2159,7 +2159,11 @@ export default class MyHandler extends Handler {
             )}`
         );
 
-        if (opt.offerReceived.sendPreAcceptMessage.enable && this.bot.friends.isFriend(offer.partner)) {
+        if (
+            !this.opt.globalDisable.offerMessages &&
+            opt.offerReceived.sendPreAcceptMessage.enable &&
+            this.bot.friends.isFriend(offer.partner)
+        ) {
             const preAcceptMessage = opt.customMessage.accepted.automatic;
 
             MyHandler.sendPreAcceptedMessage(
@@ -2226,20 +2230,27 @@ export default class MyHandler extends Handler {
                 const notifyOpt = this.opt.steamChat.notifyTradePartner;
 
                 if (offer.state === TradeOfferManager.ETradeOfferState['Accepted']) {
-                    if (notifyOpt.onSuccessAccepted) accepted(offer, this.bot);
-
+                    if (notifyOpt.onSuccessAccepted && !this.opt.globalDisable.offerMessages) {
+                        accepted(offer, this.bot);
+                    }
                     if (offer.data('donation')) {
                         this.bot.messageAdmins('✅ Success! Your donation has been sent and received!', []);
                     } else if (offer.data('buyBptfPremium')) {
                         this.bot.messageAdmins('✅ Success! Your premium purchase has been sent and received!', []);
                     }
                 } else if (offer.state === TradeOfferManager.ETradeOfferState['InEscrow']) {
-                    if (notifyOpt.onSuccessAcceptedEscrow) acceptEscrow(offer, this.bot);
+                    if (notifyOpt.onSuccessAcceptedEscrow && !this.opt.globalDisable.offerMessages) {
+                        acceptEscrow(offer, this.bot);
+                    }
                 } else if (offer.state === TradeOfferManager.ETradeOfferState['Declined']) {
-                    if (notifyOpt.onDeclined) declined(offer, this.bot);
+                    if (notifyOpt.onDeclined && !this.opt.globalDisable.offerMessages) {
+                        declined(offer, this.bot);
+                    }
                     offer.data('isDeclined', true);
                 } else if (offer.state === TradeOfferManager.ETradeOfferState['Canceled']) {
-                    if (notifyOpt.onCancelled) cancelled(offer, oldState, this.bot);
+                    if (notifyOpt.onCancelled && !this.opt.globalDisable.offerMessages) {
+                        cancelled(offer, oldState, this.bot);
+                    }
 
                     if (offer.data('canceledByUser') === true) {
                         // do nothing
@@ -2250,7 +2261,9 @@ export default class MyHandler extends Handler {
                     }
                     MyHandler.removePolldataKeys(offer);
                 } else if (offer.state === TradeOfferManager.ETradeOfferState['InvalidItems']) {
-                    if (notifyOpt.onTradedAway) invalid(offer, this.bot);
+                    if (notifyOpt.onTradedAway && !this.opt.globalDisable.offerMessages) {
+                        invalid(offer, this.bot);
+                    }
                     offer.data('isInvalid', true);
                     MyHandler.removePolldataKeys(offer);
                 }
@@ -2611,16 +2624,19 @@ export default class MyHandler extends Handler {
                 const friendSteamID = friend.steamID;
                 const getFriend = this.bot.friends.getFriend(friendSteamID);
 
-                this.bot.sendMessage(
-                    friendSteamID,
-                    this.opt.customMessage.clearFriends
-                        ? this.opt.customMessage.clearFriends.replace(
-                              /%name%/g,
-                              getFriend ? getFriend.player_name : friendSteamID
-                          )
-                        : '/quote I am cleaning up my friend list and you have randomly been selected to be removed. ' +
-                              'Please feel free to add me again if you want to trade at a later time!'
-                );
+                if (!this.bot.options.globalDisable.unfriendMessage) {
+                    this.bot.sendMessage(
+                        friendSteamID,
+                        this.opt.customMessage.clearFriends
+                            ? this.opt.customMessage.clearFriends.replace(
+                                  /%name%/g,
+                                  getFriend ? getFriend.player_name : friendSteamID
+                              )
+                            : '/quote I am cleaning up my friend list and you have randomly been selected to be removed. ' +
+                                  'Please feel free to add me again if you want to trade at a later time!'
+                    );
+                }
+
                 this.bot.client.removeFriend(friendSteamID);
             });
         }

--- a/src/classes/MyHandler/offer/review/send-review.ts
+++ b/src/classes/MyHandler/offer/review/send-review.ts
@@ -28,7 +28,7 @@ export default async function sendReview(offer: TradeOffer, bot: Bot, meta: Meta
     const isNotifyTradePartner = opt.steamChat.notifyTradePartner.onOfferForReview;
 
     // Notify partner and admin that the offer is waiting for manual review
-    if (isNotifyTradePartner) {
+    if (!opt.globalDisable.offerMessages && isNotifyTradePartner) {
         if (
             reasons.includes('⬜_BANNED_CHECK_FAILED') ||
             reasons.includes('⬜_ESCROW_CHECK_FAILED') ||

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -9,6 +9,8 @@ import { Currency } from '../types/TeamFortress2';
 export const DEFAULTS: JsonOptions = {
     globalDisable: {
         messages: false,
+        offerMessages: false,
+        unfriendMessage: false,
         greeting: false,
         commands: false,
         adminCommands: false
@@ -1196,6 +1198,8 @@ interface OnlyEnable {
 
 interface GlobalDisable {
     messages?: boolean;
+    offerMessages?: boolean;
+    unfriendMessage?: boolean;
     greeting?: boolean;
     commands?: boolean;
     adminCommands?: boolean;

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -1694,7 +1694,13 @@ export default class Trades {
                             if (!restarting) {
                                 return sendAlert('failedPM2', this.bot);
                             }
-                            this.bot.sendMessage(steamID, '🙇‍♂️ Sorry! Something went wrong. I am restarting myself...');
+                            if (this.bot.friends.isFriend(steamID)) {
+                                // Only send if friend
+                                this.bot.sendMessage(
+                                    steamID,
+                                    '🙇‍♂️ Sorry! Something went wrong. I am restarting myself...'
+                                );
+                            }
                         })
                         .catch(err => {
                             log.warn('Error occurred while trying to restart: ', err);
@@ -1717,7 +1723,12 @@ export default class Trades {
                                 );
                             }
                             this.bot.messageAdmins(`🔄 Restarting...`, []);
-                            this.bot.sendMessage(steamID, '🙇‍♂️ Sorry! Something went wrong. I am restarting myself...');
+                            if (this.bot.friends.isFriend(steamID)) {
+                                this.bot.sendMessage(
+                                    steamID,
+                                    '🙇‍♂️ Sorry! Something went wrong. I am restarting myself...'
+                                );
+                            }
                         })
                         .catch(err => {
                             log.warn('Error occurred while trying to restart: ', err);

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -367,6 +367,12 @@ export const optionsSchema: jsonschema.Schema = {
                 messages: {
                     type: 'boolean'
                 },
+                offerMessages: {
+                    type: 'boolean'
+                },
+                unfriendMessage: {
+                    type: 'boolean'
+                },
                 greeting: {
                     type: 'boolean'
                 },
@@ -377,7 +383,7 @@ export const optionsSchema: jsonschema.Schema = {
                     type: 'boolean'
                 }
             },
-            required: ['messages', 'greeting', 'commands', 'adminCommands'],
+            required: ['messages', 'offerMessages', 'unfriendMessage', 'greeting', 'commands', 'adminCommands'],
             additionalProperties: false
         },
         steamConnection: {


### PR DESCRIPTION
Less aggressive version of `globalDisable.messages`, where the bot will still be able to reply to commands.

Two new options:
- `globalDisable.offerMessages`: set to `true` if you want your bot to not send messages to partner (friend or non-friend) for incoming offers (accepted, notification about review, declined, cancelled, and traded away). Default is `false`.
- `globalDisable.unfriendMessage`: set to `true` if you want your bot to not send notification when unfriend-ing (friendlist full, or when you send `!clearfriends` command). Default is `false`.